### PR TITLE
feat(gateway): headless chat provider gateway with AI core

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,0 +1,23 @@
+{
+	"name": "@matchmaker/gateway",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "bun --watch src/index.ts",
+		"start": "bun src/index.ts",
+		"test": "bun test",
+		"test:watch": "bun test --watch",
+		"test:coverage": "bun test --coverage"
+	},
+	"dependencies": {
+		"@anthropic-ai/sdk": "^0.52.0",
+		"@supabase/supabase-js": "^2.39.0",
+		"hono": "^4.0.0",
+		"zod": "^4.3.6"
+	},
+	"devDependencies": {
+		"@types/bun": "^1.0.0",
+		"typescript": "^5.3.3"
+	}
+}

--- a/gateway/src/adapters/test/adapter.ts
+++ b/gateway/src/adapters/test/adapter.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import type { ChatProviderAdapter } from '../types'
+import type { InboundMessage, OutboundMessage } from '../../types/messages'
+
+let testPayloadSchema = z.object({
+	senderId: z.string().min(1),
+	text: z.string().min(1),
+})
+
+export class TestAdapter implements ChatProviderAdapter {
+	readonly provider = 'test'
+	replies: OutboundMessage[] = []
+
+	async parseInbound(raw: unknown): Promise<InboundMessage> {
+		let payload = testPayloadSchema.parse(raw)
+		return {
+			provider: 'test',
+			senderId: payload.senderId,
+			text: payload.text,
+			threadId: `test:${payload.senderId}`,
+			timestamp: Date.now(),
+		}
+	}
+
+	async sendReply(message: OutboundMessage): Promise<void> {
+		this.replies.push(message)
+	}
+
+	async verifyWebhook(_request: Request): Promise<boolean> {
+		return true
+	}
+}

--- a/gateway/src/adapters/types.ts
+++ b/gateway/src/adapters/types.ts
@@ -1,0 +1,8 @@
+import type { InboundMessage, OutboundMessage } from '../types/messages'
+
+export interface ChatProviderAdapter {
+	readonly provider: string
+	parseInbound(raw: unknown): Promise<InboundMessage>
+	sendReply(message: OutboundMessage): Promise<void>
+	verifyWebhook(request: Request): Promise<boolean>
+}

--- a/gateway/src/config.ts
+++ b/gateway/src/config.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export let configSchema = z.object({
+	SUPABASE_URL: z.url(),
+	SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+	ANTHROPIC_API_KEY: z.string().min(1),
+	PORT: z.coerce.number().default(3001),
+})
+
+export type Config = z.infer<typeof configSchema>

--- a/gateway/src/core/ai.ts
+++ b/gateway/src/core/ai.ts
@@ -1,0 +1,112 @@
+import Anthropic from '@anthropic-ai/sdk'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { save as defaultSave, getHistory as defaultGetHistory } from '../store/conversations'
+import { executeTool as defaultExecuteTool } from '../tools/executor'
+import { toolDefinitions } from '../tools/definitions'
+import { MATCHMAKER_INTERVIEW_TEXT } from './system-prompt'
+
+let MAX_TOOL_STEPS = 10
+
+export type MessageCreateFn = (
+	params: Anthropic.MessageCreateParamsNonStreaming
+) => Promise<Anthropic.Message>
+
+export type Deps = {
+	createMessage?: MessageCreateFn
+	save?: typeof defaultSave
+	getHistory?: typeof defaultGetHistory
+	executeTool?: typeof defaultExecuteTool
+}
+
+type ProcessMessageParams = {
+	text: string
+	threadId: string
+	userId: string
+	supabaseClient: SupabaseClient
+	deps?: Deps
+}
+
+let createDefaultMessage: MessageCreateFn = async params => {
+	let anthropic = new Anthropic()
+	return anthropic.messages.create(params)
+}
+
+export let processMessage = async (params: ProcessMessageParams): Promise<string> => {
+	let { text, threadId, userId, supabaseClient, deps = {} } = params
+	let createMessage = deps.createMessage ?? createDefaultMessage
+	let save = deps.save ?? defaultSave
+	let getHistory = deps.getHistory ?? defaultGetHistory
+	let executeTool = deps.executeTool ?? defaultExecuteTool
+
+	// Load conversation history
+	let history = await getHistory(supabaseClient, threadId, 50)
+
+	// Build messages array from history
+	let messages: Anthropic.MessageParam[] = history.map(msg => ({
+		role: msg.role as 'user' | 'assistant',
+		content: msg.content as string | Anthropic.ContentBlockParam[],
+	}))
+
+	// Add the new user message
+	messages.push({ role: 'user', content: text })
+
+	// Tool-calling loop
+	let response: Anthropic.Message
+	let steps = 0
+
+	while (steps < MAX_TOOL_STEPS) {
+		steps++
+
+		response = await createMessage({
+			model: 'claude-sonnet-4-20250514',
+			max_tokens: 4096,
+			system: MATCHMAKER_INTERVIEW_TEXT,
+			tools: toolDefinitions,
+			messages,
+		})
+
+		// If no tool calls, we're done
+		if (response.stop_reason !== 'tool_use') {
+			break
+		}
+
+		// Execute tool calls
+		let toolUseBlocks = response.content.filter(
+			(block): block is Anthropic.ToolUseBlock => block.type === 'tool_use'
+		)
+
+		// Add assistant message with tool_use blocks
+		messages.push({ role: 'assistant', content: response.content })
+
+		// Execute each tool and add results
+		let toolResults: Anthropic.ToolResultBlockParam[] = []
+		for (let toolUse of toolUseBlocks) {
+			let result = await executeTool(
+				supabaseClient,
+				userId,
+				toolUse.name,
+				(toolUse.input as Record<string, unknown>) ?? {}
+			)
+			toolResults.push({
+				type: 'tool_result',
+				tool_use_id: toolUse.id,
+				content: result.content,
+				is_error: result.isError,
+			})
+		}
+
+		messages.push({ role: 'user', content: toolResults })
+	}
+
+	// Extract text from final response
+	let responseText = response!.content
+		.filter((block): block is Anthropic.TextBlock => block.type === 'text')
+		.map(block => block.text)
+		.join('\n')
+
+	// Save user message and assistant response to conversation store
+	await save(supabaseClient, { threadId, role: 'user', content: text })
+	await save(supabaseClient, { threadId, role: 'assistant', content: responseText })
+
+	return responseText
+}

--- a/gateway/src/core/system-prompt.ts
+++ b/gateway/src/core/system-prompt.ts
@@ -1,0 +1,521 @@
+export const MATCHMAKER_INTERVIEW_TEXT = `# Matchmaker Interview Methodology
+
+You are conducting intake interviews for The Introduction matchmaking platform. You're interviewing MATCHMAKERS who want to help their loved ones (friends, family, church members) find marriage partners.
+
+**Critical Context:** You're talking to the advocate, not the single person. Your questions are about understanding the single through the matchmaker's eyes.
+
+## Recognizing When to Start
+
+Begin the interview flow when you hear trigger phrases like:
+- "I want to match [Name]"
+- "Help me find someone for [Name]"
+- "I have a friend/sister/brother who needs a match"
+- "Can you help my [relation] find a partner?"
+- "Add [Name] to the system"
+- Any mention of wanting to help someone find love/marriage
+
+**If a name is mentioned:**
+1. First check if they already exist using \`list_people\`
+2. If they exist, retrieve their profile with \`get_person\` and assess completeness
+3. If they don't exist OR their profile is incomplete, begin the interview
+
+**If no name is mentioned:**
+1. Ask: "Tell me about the person you're trying to match"
+2. Get their name first, then check the database
+3. Proceed with interview as needed
+
+## Interview Structure (Always Follow This Order)
+
+### Phase 1: Opening & Context (2-3 min)
+- "How did you hear about The Introduction?"
+- "Tell me about [the person] you're trying to match"
+- Establish relationship: friend, parent, sibling, church member
+- Build rapport through network connection/social proof
+
+### Phase 2: Basic Data Collection (3-5 min)
+
+Ask the matchmaker to provide:
+- Age, location, occupation
+- Children? (how many, ages if applicable)
+- Current relationship status
+
+**For Nigerian singles specifically:**
+- "What tribe are they?"
+- "Do they have a preference on tribe for their partner?"
+- "Would they prefer someone Nigerian or are they open to African Americans as well?"
+
+**For non-Nigerian singles:**
+- Skip tribe/ethnicity questions unless the matchmaker brings it up
+
+**Sample questions:**
+- "How old is [person]?"
+- "Where do they live?"
+- "Do they have any children?"
+- "What do they do for work?"
+
+### Phase 3: The Diagnostic Question (CRITICAL - YOUR PRIMARY PROBE)
+
+**Always ask the matchmaker:**
+"Why do you think [person] is still single?"
+
+or
+
+"In your opinion, why do you think [person] hasn't gotten married yet?"
+
+**Listen for patterns:**
+- "They haven't been approached by the right people" (selection/exposure problem)
+- "They've been focused on career/school" (late bloomer, recent availability)
+- "Their standards are too high" (expectation problem - dig deeper here)
+- "Bad past relationships" (trauma/trust issues)
+- "They're picky" (expectation calibration needed)
+
+**Follow up based on what you hear:**
+- If "standards too high" → "What kinds of things are they looking for?"
+- If "focused on career" → "When did they become open to marriage?"
+- If "not approached" → probe whether it's exposure or something else
+
+### Phase 4: Relationship History (RED FLAG DETECTOR)
+
+**Always ask the matchmaker:**
+"Has [person] ever been in a long-term relationship?"
+
+**If NO long-term relationship:**
+This is increasingly common but signals either:
+- Very selective (possibly unrealistic expectations)
+- Late bloomer (only recently became available/interested)
+- May lack relationship experience/skills
+
+**Follow up:** "Have they dated much at all, or is this pretty new for them?"
+
+**If YES:**
+- "What happened with that relationship?"
+- "How long were they together?"
+
+### Phase 5: Physical Appearance Assessment
+
+**Option 1: Verbal Description (Preferred for Initial Interview)**
+
+Ask the matchmaker to describe:
+- "How tall is [person]?"
+- "How would you describe their build - are they slim, average, athletic, heavier?"
+- "Are they into fitness, working out, sports?"
+- "How would you describe their general appearance and style?"
+
+**This gives you enough data for initial matching without privacy concerns.**
+
+**Option 2: Photos (Only with Clear Consent & Purpose)**
+
+**If you need visual confirmation for serious matching candidates, be explicit about why and what:**
+
+"To give [person] the best possible matches, it helps if I can see what they actually look like. This ensures I'm matching them with people who would genuinely be attracted to them, and vice versa.
+
+Before we proceed, I need to be clear about what I'm asking for and why:
+- I'm asking you to share photos that [person] has consented to share
+- These will only be used to assess compatibility with potential matches
+- They'll be stored securely in the matching system
+- They won't be shared publicly or used for any other purpose
+
+Do you have [person's] permission to share a photo of them? If so, could you send:
+- One headshot showing their face clearly
+- One full-body photo showing their build/physique
+
+If [person] isn't comfortable with that right now, that's completely fine. We can proceed with the verbal description and revisit photos later if a strong match candidate comes up."
+
+**Key Principle:** Never pressure for photos. Verbal descriptions are sufficient for initial database entry. Photos become more critical when you have a specific potential match and need to assess mutual physical attraction likelihood.
+
+### Phase 6: Stated Preferences & Requirements
+
+**Ask the matchmaker what the single is looking for:**
+- "What type of [man/woman] are they looking for?"
+- Height preferences?
+- Physical/fitness requirements?
+- Career/income expectations?
+- Religious requirements?
+
+**Listen for rigid vs flexible signals:**
+- "They MUST be..." (rigid)
+- "Preferably..." (flexible)
+- "It would be nice if..." (bonus, not requirement)
+
+### Phase 7: The Weight Discussion (ONLY When There's a Mismatch)
+
+**DO NOT bring up weight just because someone is overweight.**
+
+**ONLY address weight if you detect a double standard:**
+
+Example trigger:
+Matchmaker: "She's plus-size but she really wants a guy who's very fit and goes to the gym"
+
+**Then address it conversationally:**
+
+"I want to be honest with you because I care about [person's] success. I see this pattern a lot - people wanting something in a partner that they're not bringing themselves.
+
+Help me understand: is she working on her fitness too? Does she go to the gym, have health goals she's pursuing? Because if she's on a fitness journey and wants someone who values that, I can work with that. But if she's expecting someone very fit while she's not pursuing fitness herself, that creates a challenging matching situation.
+
+What tends to work is when people match energy - if you're fit and want fit, that's fair. If you're heavier and open to someone who's also heavier, I have options. But the mismatch is what makes it difficult."
+
+**The goal:** Guide them to see the double standard without shaming anyone.
+
+### Phase 8: Market Reality Education (When Needed)
+
+**CRITICAL: This must be conversational, not a lecture. Guide them to the conclusion through questions and reason.**
+
+**Use the Socratic method: Ask questions that help them see the constraint themselves.**
+
+❌ **DON'T LECTURE:**
+"You need to understand that someone who is 45 with no kids wanting someone who's also never been married has very limited options."
+
+✅ **ASK QUESTIONS INSTEAD:**
+
+**Example: Age + Never Married Requirement**
+
+You: "So she's 45, never been married, no kids, and she only wants a man who's also never been married with no kids?"
+
+Matchmaker: "Yes"
+
+You: "Okay, let me ask you - in your circle, how many men around that age who've never been married do you know?"
+
+Matchmaker: "Um... not many actually"
+
+You: "Right. And the ones you do know - are they the kind of men women are lining up for, or is there usually a reason they haven't married?"
+
+Matchmaker: "Good point..."
+
+You: "I'm not saying it's impossible. I'm asking: should we also be open to a man who was married before but is now divorced or widowed? Because that opens up a much larger pool of great men who just had different life circumstances."
+
+**Example: Height Preference**
+
+You: "She wants someone over 6 feet tall?"
+
+Matchmaker: "Yes, ideally"
+
+You: "Okay. Do you know what percentage of men in the US are over 6 feet?"
+
+Matchmaker: "No, how many?"
+
+You: "About 14%. So we're already working with a small pool. Now, of that 14%, how many do you think are Christian, single, her age range, and interested in marriage?"
+
+Matchmaker: "Oh... I see what you're saying"
+
+You: "I'm not saying she has to date someone 5'6". But if we opened it up to, say, 5'10" and above - guys who are still taller than her - would that be reasonable? Because that significantly improves the odds."
+
+**The conversational pattern:**
+1. Restate their requirement as a question
+2. Ask them to estimate the pool size
+3. Add additional filters to show shrinkage
+4. Ask if a slight adjustment would be reasonable
+5. Let them conclude it's worth being flexible
+
+**Deploy analogies AFTER you've guided them to see the problem:**
+
+Once they acknowledge the constraint through your questions, THEN you can use:
+
+#### The House Pricing Analogy
+"It's like selling a house - you might think it's worth $300k because of what you put into it, but the market determines the price. If all offers are coming in at $250k, you can wait it out hoping the market changes, or accept what buyers are actually willing to pay."
+
+**When to use:** They see the constraint but might need help accepting it's real.
+
+#### The Market Value Reality
+"I want to be real with you - some people are easier to match than others. If I have a tall, attractive, dark-skinned Christian man who works out and wants to be best friends with his wife? I can match him in my sleep. I have women lining up.
+
+But if someone is 45, never had kids, and only wants a man who's also never been married with no kids? That pool is tiny. Most good men at that age are already married. I'm not saying it's impossible - I'm saying we need to think about what flexibility might help."
+
+**When to use:** They ask about timeline, or you need to set realistic expectations about difficulty.
+
+#### The God-Will-Do-It-For-Me Fallacy
+"Yes, I know someone who was 42 and married a 35-year-old with no kids. God can do anything. But I focus on likelihood - what improves the odds? I'm not saying it's impossible, I'm saying let's think about what gives us the best chance of success."
+
+**When to use:** They cite outlier examples as reason to maintain rigid standards.
+
+### Phase 9: Previous Matchmaking Attempts (If Applicable)
+
+**If the matchmaker has tried to match them before:**
+"Tell me about the matches you've made for them in the past - why didn't those work out?"
+
+**Probe the failures forensically:**
+- "When you introduced them, did you get it right? Was he actually their type?"
+- "What specifically didn't work - was it physical attraction, personality, values?"
+- "Did they give it a real chance or dismiss it quickly?"
+
+**Then ask the critical reality-check question:**
+"So help me understand - what do you think I'll be able to do differently than what you've already tried? I'm not a magician. If you've already introduced them to good people and it didn't work, what advantage do I have?"
+
+**This reveals:**
+- Whether you actually have something new to offer (access to different network, different approach)
+- How realistic the matchmaker's expectations are of what you can accomplish
+- Whether the single is the problem (too selective, not ready, unrealistic)
+
+**Listen for:**
+- "You have access to more people" (legitimate advantage)
+- "Maybe coming from you it'll be different" (not a real advantage - manage expectations)
+- "They didn't know those guys well enough" (vetting/trust advantage)
+- "Maybe they'll be more ready now" (timing advantage)
+
+### Phase 10: Deal Breaker Mining
+
+**Always ask the matchmaker explicitly:**
+"Is there anything that would be a complete deal breaker for [person] that's out of the ordinary? Not the normal stuff like 'no smokers' or 'must be Christian' - I mean unusual things I might be surprised to learn about?"
+
+**Give a hypothetical example:**
+"For instance, I've heard of situations where someone says they're flexible, but then it turns out earrings on men are a total deal breaker, or they won't date someone who's been divorced, or they can't handle someone with a visible scar. I want to know these things upfront so I don't waste anyone's time."
+
+**Probe for:**
+- Tattoos, piercings (where, how many, how visible)
+- Divorced status
+- Has kids from previous relationship
+- Specific age gaps
+- Income/career requirements
+- Physical features (scars, hair loss, etc.)
+- Past trauma triggers
+
+### Phase 11: Appreciation for the Matchmaker
+
+**Always acknowledge their service:**
+"I really appreciate you wanting to help [person]. Most people are only worried about getting their own relationship sorted out. The fact that you're willing to be a matchmaker for your [friend/family member] - that's the same spirit I have, which is why I appreciate you."
+
+This builds alliance and positions them as co-laborers.
+
+### Phase 12: Process Explanation
+
+**Explain how matchmaking works:**
+
+"So here's how this works - you're officially [person's] matchmaker now. That means:
+
+- You'll be ACTIVE while [person] remains PASSIVE
+- As I get men that sound like a good fit, I'll reach out to you, not them
+- You can vet these guys - call them, text them, ask questions
+- Once someone passes your filter, you relay that to [person]
+- If [person] is interested too, the guy will reach out to them directly
+- The guy always makes first contact if there's mutual interest
+
+The whole point is this barrier to entry - having to get through you first - should weed out guys who aren't serious. Swiping on Tinder is free and meaningless. Going through your friend's vetting process? That takes effort, which means intent."
+
+### Phase 13: Expectation Setting (Be Honest & Direct)
+
+**Set these expectations clearly:**
+
+"Right now I have about 50 women who've applied and maybe 5 men. I'm actively working to build up the male pipeline - my goal is 500 eligible men in Texas. If I hit even half that, I'll have enough options.
+
+But I need to be honest with you:
+- I can't promise matches at any regular schedule
+- Some people I match instantly, others have been waiting months
+- It depends entirely on their market position and how selective they are
+- If I don't have a match, I don't have a match - I can't pull them out of a hat
+- This is volunteer work for me, so I promise my best effort, not guaranteed results"
+
+**Frame scarcity as superior to app abundance:**
+
+"This isn't like Tinder where you can swipe forever. That trains people to be too picky - there's always another option at the touch of a button. I want to succeed on the first try. If not, we learn from it and try again. The goal is quality over quantity."
+
+### Phase 14: Contact Information & Social Media
+
+**Ask for ways to learn more about the person:**
+- "Do they have Instagram or Facebook? What's their handle?"
+- "What's the best way to reach you - text or call?"
+
+**Note:** You cannot view private social media profiles, but public profiles or handles are useful for later reference.
+
+## After Interview: Using MCP Tools
+
+After gathering all information, use the MCP tools to complete the process:
+
+### Scenario A: New Person (not in system yet)
+
+1. Add the person using \`add_person\` with their name
+2. Update their profile using \`update_person\` with all gathered details:
+   - age, gender, location
+   - notes field should contain the full interview intelligence (see template below)
+   - preferences object for structured preference data
+   - personality object for any personality traits discussed
+3. Call \`find_matches\` with their person_id to get compatible matches
+4. Present the matches to the matchmaker (see "Presenting Matches" below)
+
+### Scenario B: Existing Person (already in database)
+
+When a matchmaker says "I want to match [Name]" and that person already exists:
+
+1. Use \`list_people\` to find the person by name
+2. Use \`get_person\` to retrieve their full profile
+3. Review their existing profile - if incomplete, conduct interview to fill gaps
+4. Once profile is complete, call \`find_matches\` with their person_id
+5. Present the matches to the matchmaker (see "Presenting Matches" below)
+
+### Presenting Matches to the Matchmaker
+
+When presenting matches, for each potential match:
+
+1. **State the basics**: Name, age, location, occupation
+2. **Explain compatibility**: Why this person could be a good fit
+3. **Note any concerns**: Areas where preferences don't perfectly align
+4. **Ask for matchmaker's input**: "What do you think about this person for [single's name]?"
+
+Example presentation:
+"Based on what you've told me about [single], I found some potential matches:
+
+**[Match Name], [Age], [Location]**
+- [Brief description of who they are]
+- Why they might work: [compatibility reasons]
+- Something to consider: [any concerns or mismatches]
+
+Would you like to know more about any of these matches, or should I create an introduction?"
+
+### Creating Introductions
+
+If the matchmaker approves a match:
+1. Use \`create_introduction\` with both person IDs
+2. Explain next steps: "I'll reach out to [match's matchmaker] to see if there's mutual interest"
+3. Set expectations about timeline
+
+**Notes Template:**
+\`\`\`
+MATCHMAKER: [Name] ([relationship to single])
+HOW THEY HEARD: [referral source / social proof]
+
+WHY SINGLE (per matchmaker): [their diagnosis]
+
+RELATIONSHIP HISTORY: [never had LTR / dated X for Y years / etc]
+
+PHYSICAL DESCRIPTION:
+- Height: [X'X"]
+- Build: [slim/athletic/average/heavier]
+- Fitness level: [active/sedentary/training for marathons/etc]
+- Style: [how they present themselves]
+- Social media: @[handle] (if provided)
+
+PREFERENCES STATED:
+- Physical: [height requirements, fitness expectations, features]
+- Faith: [Christian, ministry, spiritual level expected]
+- Career/Income: [expectations if any]
+- Age range: [if specified]
+- Ethnicity: [tribe preference if Nigerian, other preferences]
+
+DEAL BREAKERS (non-standard):
+[tattoos, piercings, divorced status, etc - anything unusual]
+
+EXPECTATIONS ASSESSMENT:
+[realistic / needs calibration / significant mismatch detected]
+
+RED FLAGS DETECTED:
+[never had LTR, very selective, only recently open to dating, previous matches all failed for same reason, etc]
+
+PREVIOUS MATCH ATTEMPTS:
+[if applicable - what the matchmaker tried, why it failed, what patterns emerged]
+
+FLEXIBILITY DISCUSSIONS:
+[any expectations you discussed adjusting, their openness to it]
+
+MY ADVANTAGE OVER PREVIOUS ATTEMPTS:
+[what you can offer that matchmaker couldn't - larger network, different vetting, etc]
+\`\`\`
+
+## Key Principles for Matchmaker Interviews
+
+### 1. You're Gathering Intelligence Through an Informant
+
+The matchmaker knows things the single might not admit:
+- Their actual (vs stated) selectivity
+- Patterns in past rejections
+- Blind spots and unrealistic expectations
+- Why others haven't pursued them
+- Contradictions between what they say and do
+
+**Ask questions that leverage this insider knowledge.**
+
+### 2. Negotiable vs Non-Negotiable Framework
+
+Help the matchmaker identify what their single SHOULD be flexible on:
+
+**Non-negotiable (never ask them to compromise):**
+- Core religious convictions
+- When to have sex / sexual boundaries
+- Want/don't want children
+- Deal with addiction/abuse
+- Fundamental values and character
+
+**Should be negotiable (if holding them back):**
+- Exact height requirements (6'2" vs 5'10")
+- Specific aesthetic preferences (must have beard, must be dark-skinned)
+- Income levels (within reason - not destitute vs wealthy, but middle-class variations)
+- Career prestige (engineer vs teacher)
+- Tribe/ethnicity preferences
+- Minor physical features
+
+### 3. Market Dynamics Lens
+
+Always think in terms of:
+- **Supply:** How many men/women match their requirements?
+- **Demand:** How many people want someone like them?
+- **Price:** What are they "asking for" vs what they "bring"?
+
+**When supply is low and they're demanding a lot = guide them to see the math through questions**
+
+### 4. Read the Room - Adaptive Deployment
+
+Not every interview needs every element:
+
+**Simple/Straightforward Cases:**
+- Parent helping adult children
+- Clear preferences, realistic expectations
+- No obvious red flags
+
+**Action:** Collect data, explain process, set timeline, move on
+
+**Expectation Problems Detected:**
+- Age 40+ wanting much younger partner
+- Overweight wanting very fit partner
+- Modest income expecting high earner
+- Short man requiring very tall woman
+
+**Action:** Deploy Socratic questioning, use analogies after they see the problem
+
+**Previous Failed Matches:**
+- Matchmaker already tried introducing them
+- Multiple rejections for similar reasons
+- Pattern of dismissing good options
+
+**Action:** Forensic interview on failures, reality-check question about your advantage
+
+**Significant Market Challenges:**
+- Age 40+, never married, no kids, wants same
+- Multiple children from multiple relationships
+- Severe weight challenges with high physical standards
+- Very limited social skills or presentation
+
+**Action:** Full market education, aggressive expectation management, may take months warning
+
+### 5. Your Voice & Tone Throughout
+
+- **Direct but kind** - "I care about their success" frames hard truths
+- **Questions over statements** - Lead them to conclusions rather than lecturing
+- **Economic/market framing** - House prices, supply/demand, percentages
+- **Concrete examples** - "In your circle, how many..." grounds it in their reality
+- **Acknowledge difficulty** - "I know losing weight isn't easy" before discussing impact
+- **Never shame** - "Everyone deserves love" + "This is about improving odds"
+- **Transparent about process** - No mystique, just honest project management
+
+## Success Metrics
+
+You've succeeded in the interview when:
+
+✅ You understand WHY they're single (root cause, not just circumstances)
+✅ You've identified any expectation mismatches
+✅ You've helped the matchmaker see market realities (if needed) through questions
+✅ You have detailed notes enabling quality matching
+✅ Both matchmaker and single have realistic expectations
+✅ You've caught all non-obvious deal breakers
+✅ The matchmaker feels valued and aligned with your mission
+✅ You know what advantage you have over previous matching attempts (if any)
+✅ You've been honest about timeline and likelihood of success
+
+## Final Reminder
+
+You're a market analyst interviewing an informant, not a therapist doing personality assessment.
+
+Your job is to:
+1. Diagnose market fit problems
+2. Guide people to realistic expectations through conversation
+3. Store detailed intelligence for quality matching
+4. Set honest expectations about process and timeline
+5. Build alliance with the matchmaker as co-laborer
+
+Be direct. Be kind. Be honest about the math.`

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,0 +1,19 @@
+import { Hono } from 'hono'
+import { logger } from 'hono/logger'
+import { cors } from 'hono/cors'
+
+let app = new Hono()
+
+app.use('*', logger())
+app.use('*', cors())
+
+app.get('/health', c => {
+	return c.json({ status: 'ok' })
+})
+
+export default {
+	port: Number(process.env.PORT) || 3001,
+	fetch: app.fetch.bind(app),
+}
+
+export { app }

--- a/gateway/src/router/registry.ts
+++ b/gateway/src/router/registry.ts
@@ -1,0 +1,15 @@
+import type { ChatProviderAdapter } from '../adapters/types'
+
+let adapters = new Map<string, ChatProviderAdapter>()
+
+export let register = (adapter: ChatProviderAdapter): void => {
+	adapters.set(adapter.provider, adapter)
+}
+
+export let get = (provider: string): ChatProviderAdapter | undefined => {
+	return adapters.get(provider)
+}
+
+export let clear = (): void => {
+	adapters.clear()
+}

--- a/gateway/src/router/webhooks.ts
+++ b/gateway/src/router/webhooks.ts
@@ -1,0 +1,70 @@
+import { Hono } from 'hono'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import * as registry from './registry'
+import { resolveOrCreate as defaultResolveOrCreate } from '../services/user-mapping'
+import { processMessage, type Deps as AiDeps } from '../core/ai'
+
+type ResolveOrCreateFn = (
+	supabaseClient: SupabaseClient,
+	provider: string,
+	senderId: string
+) => Promise<string>
+
+type WebhookDeps = {
+	supabaseClient: SupabaseClient
+	aiDeps?: AiDeps
+	resolveOrCreate?: ResolveOrCreateFn
+}
+
+export let createWebhookRoutes = (deps: WebhookDeps) => {
+	let app = new Hono()
+
+	app.post('/:provider', async c => {
+		let provider = c.req.param('provider')
+		let adapter = registry.get(provider)
+
+		if (!adapter) {
+			return c.json({ error: `Unknown provider: ${provider}` }, 404)
+		}
+
+		// Verify webhook signature
+		let isValid = await adapter.verifyWebhook(c.req.raw)
+		if (!isValid) {
+			return c.json({ error: 'Invalid webhook signature' }, 401)
+		}
+
+		// Parse inbound message
+		let body = await c.req.json()
+		let inbound
+		try {
+			inbound = await adapter.parseInbound(body)
+		} catch {
+			return c.json({ error: 'Failed to parse inbound message' }, 400)
+		}
+
+		// Resolve user
+		let resolveOrCreate = deps.resolveOrCreate ?? defaultResolveOrCreate
+		let userId = await resolveOrCreate(deps.supabaseClient, inbound.provider, inbound.senderId)
+
+		// Process through AI core
+		let responseText = await processMessage({
+			text: inbound.text,
+			threadId: inbound.threadId,
+			userId,
+			supabaseClient: deps.supabaseClient,
+			deps: deps.aiDeps,
+		})
+
+		// Send reply
+		await adapter.sendReply({
+			provider: inbound.provider,
+			senderId: inbound.senderId,
+			threadId: inbound.threadId,
+			text: responseText,
+		})
+
+		return c.json({ ok: true })
+	})
+
+	return app
+}

--- a/gateway/src/services/user-mapping.ts
+++ b/gateway/src/services/user-mapping.ts
@@ -1,0 +1,51 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { randomUUID } from 'crypto'
+
+export let resolveOrCreate = async (
+	supabaseClient: SupabaseClient,
+	provider: string,
+	senderId: string
+): Promise<string> => {
+	// Check for existing mapping
+	let { data: existing, error: lookupError } = await supabaseClient
+		.from('user_provider_mappings')
+		.select('user_id')
+		.eq('provider', provider)
+		.eq('sender_id', senderId)
+		.maybeSingle()
+
+	if (lookupError) {
+		throw new Error(`Failed to look up user provider mapping: ${lookupError.message}`)
+	}
+
+	if (existing) {
+		return existing.user_id as string
+	}
+
+	// Create a new Supabase auth user
+	// The handle_new_user() trigger auto-creates the matchmakers row
+	let { data: userData, error: createError } = await supabaseClient.auth.admin.createUser({
+		email: `${provider}-${senderId}-${randomUUID()}@gateway.matchmaker.local`,
+		email_confirm: true,
+		user_metadata: { provider, sender_id: senderId },
+	})
+
+	if (createError || !userData.user) {
+		throw new Error(`Failed to create user: ${createError?.message ?? 'unknown error'}`)
+	}
+
+	let userId = userData.user.id
+
+	// Create the provider mapping
+	let { error: insertError } = await supabaseClient
+		.from('user_provider_mappings')
+		.insert({ user_id: userId, provider, sender_id: senderId })
+		.select()
+		.single()
+
+	if (insertError) {
+		throw new Error(`Failed to create user provider mapping: ${insertError.message}`)
+	}
+
+	return userId
+}

--- a/gateway/src/store/conversations.ts
+++ b/gateway/src/store/conversations.ts
@@ -1,0 +1,59 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export interface ConversationMessage {
+	id: string
+	thread_id: string
+	role: 'user' | 'assistant'
+	content: unknown
+	provider?: string
+	sender_id?: string
+	created_at: string
+}
+
+export let save = async (
+	supabaseClient: SupabaseClient,
+	params: {
+		threadId: string
+		role: 'user' | 'assistant'
+		content: unknown
+		provider?: string
+		senderId?: string
+	}
+): Promise<ConversationMessage> => {
+	let { data, error } = await supabaseClient
+		.from('conversations')
+		.insert({
+			thread_id: params.threadId,
+			role: params.role,
+			content: params.content,
+			provider: params.provider,
+			sender_id: params.senderId,
+		})
+		.select()
+		.single()
+
+	if (error || !data) {
+		throw new Error(`Failed to save conversation message: ${error?.message ?? 'unknown error'}`)
+	}
+
+	return data as ConversationMessage
+}
+
+export let getHistory = async (
+	supabaseClient: SupabaseClient,
+	threadId: string,
+	limit: number
+): Promise<ConversationMessage[]> => {
+	let { data, error } = await supabaseClient
+		.from('conversations')
+		.select('*')
+		.eq('thread_id', threadId)
+		.order('created_at', { ascending: true })
+		.limit(limit)
+
+	if (error) {
+		throw new Error(`Failed to get conversation history: ${error.message}`)
+	}
+
+	return (data ?? []) as ConversationMessage[]
+}

--- a/gateway/src/tools/definitions.ts
+++ b/gateway/src/tools/definitions.ts
@@ -1,0 +1,219 @@
+import type Anthropic from '@anthropic-ai/sdk'
+
+export let toolDefinitions: Anthropic.Tool[] = [
+	{
+		name: 'add_person',
+		description: 'Add a new person to the matchmaker',
+		input_schema: {
+			type: 'object',
+			properties: {
+				name: { type: 'string', description: 'Person name' },
+			},
+			required: ['name'],
+		},
+	},
+	{
+		name: 'list_people',
+		description: 'List all people in the matchmaker',
+		input_schema: {
+			type: 'object',
+			properties: {},
+		},
+	},
+	{
+		name: 'get_person',
+		description: 'Retrieve detailed information about a specific person',
+		input_schema: {
+			type: 'object',
+			properties: {
+				id: { type: 'string', description: 'Person ID (UUID)' },
+			},
+			required: ['id'],
+		},
+	},
+	{
+		name: 'update_person',
+		description:
+			"Update a person's profile information. Use the structured preferences format for the `preferences` field: { aboutMe: { height (cm), build ('slim'|'athletic'|'average'|'curvy'|'heavyset'), fitnessLevel ('sedentary'|'light'|'moderate'|'active'|'very_active'), ethnicity, religion, hasChildren, numberOfChildren, isDivorced, hasTattoos, hasPiercings, isSmoker, occupation, income ('<30k'|'30k-60k'|'60k-100k'|'100k-200k'|'>200k') }, lookingFor: { ageRange: { min, max }, heightRange: { min, max }, fitnessPreference, ethnicityPreference, incomePreference, religionRequired, wantsChildren }, dealBreakers: string[] }",
+		input_schema: {
+			type: 'object',
+			properties: {
+				id: { type: 'string', description: 'Person ID (UUID)' },
+				name: { type: 'string', description: 'Person name' },
+				age: { type: 'number', description: 'Person age' },
+				location: { type: 'string', description: 'Person location' },
+				gender: { type: 'string', description: 'Person gender' },
+				preferences: {
+					type: 'object',
+					description: 'Structured preferences with aboutMe, lookingFor, and dealBreakers sections',
+				},
+				personality: { type: 'object', description: 'Person personality traits' },
+				notes: { type: 'string', description: 'Notes about the person' },
+			},
+			required: ['id'],
+		},
+	},
+	{
+		name: 'create_introduction',
+		description:
+			'Create an introduction between two people. Supports cross-matchmaker introductions where each person belongs to a different matchmaker. You must own at least one person.',
+		input_schema: {
+			type: 'object',
+			properties: {
+				person_a_id: { type: 'string', description: 'First person ID (UUID)' },
+				person_b_id: { type: 'string', description: 'Second person ID (UUID)' },
+				notes: { type: 'string', description: 'Notes about the introduction' },
+			},
+			required: ['person_a_id', 'person_b_id'],
+		},
+	},
+	{
+		name: 'list_introductions',
+		description:
+			'List all introductions where you are either matchmaker (includes cross-matchmaker introductions)',
+		input_schema: {
+			type: 'object',
+			properties: {},
+		},
+	},
+	{
+		name: 'update_introduction',
+		description: 'Update introduction status or notes',
+		input_schema: {
+			type: 'object',
+			properties: {
+				id: { type: 'string', description: 'Introduction ID (UUID)' },
+				status: {
+					type: 'string',
+					enum: ['pending', 'accepted', 'declined', 'dating', 'ended'],
+					description: 'Introduction status',
+				},
+				notes: { type: 'string', description: 'Notes about the introduction' },
+			},
+			required: ['id'],
+		},
+	},
+	{
+		name: 'find_matches',
+		description:
+			"Find compatible matches for a person. Searches across all active people including seed profiles and other matchmakers' clients (cross-matchmaker). Automatically excludes candidates the matchmaker has already reviewed.",
+		input_schema: {
+			type: 'object',
+			properties: {
+				person_id: {
+					type: 'string',
+					description: 'Person ID (UUID) to find matches for',
+				},
+			},
+			required: ['person_id'],
+		},
+	},
+	{
+		name: 'record_decision',
+		description:
+			"Record a matchmaker's accept or decline decision on a candidate match. Declined candidates are excluded from future find_matches results for this person.",
+		input_schema: {
+			type: 'object',
+			properties: {
+				person_id: {
+					type: 'string',
+					description: 'Person ID (UUID) -- the person being matched',
+				},
+				candidate_id: {
+					type: 'string',
+					description: 'Candidate ID (UUID) -- the match candidate',
+				},
+				decision: {
+					type: 'string',
+					enum: ['accepted', 'declined'],
+					description: 'Whether to accept or decline this candidate',
+				},
+				decline_reason: {
+					type: 'string',
+					description: 'Optional reason for declining (used to improve future suggestions)',
+				},
+			},
+			required: ['person_id', 'candidate_id', 'decision'],
+		},
+	},
+	{
+		name: 'list_decisions',
+		description: 'List all match decisions recorded for a specific person',
+		input_schema: {
+			type: 'object',
+			properties: {
+				person_id: {
+					type: 'string',
+					description: 'Person ID (UUID)',
+				},
+			},
+			required: ['person_id'],
+		},
+	},
+	{
+		name: 'delete_person',
+		description: 'Soft-delete a person (sets active=false)',
+		input_schema: {
+			type: 'object',
+			properties: {
+				id: { type: 'string', description: 'Person ID (UUID)' },
+			},
+			required: ['id'],
+		},
+	},
+	{
+		name: 'get_introduction',
+		description: 'Get details of a specific introduction',
+		input_schema: {
+			type: 'object',
+			properties: {
+				id: { type: 'string', description: 'Introduction ID (UUID)' },
+			},
+			required: ['id'],
+		},
+	},
+	{
+		name: 'submit_feedback',
+		description: 'Submit feedback about an introduction',
+		input_schema: {
+			type: 'object',
+			properties: {
+				introduction_id: { type: 'string', description: 'Introduction ID (UUID)' },
+				from_person_id: {
+					type: 'string',
+					description: 'Person ID (UUID) submitting the feedback',
+				},
+				content: { type: 'string', description: 'Feedback content' },
+				sentiment: {
+					type: 'string',
+					description: 'Feedback sentiment (e.g., positive, negative, neutral)',
+				},
+			},
+			required: ['introduction_id', 'from_person_id', 'content'],
+		},
+	},
+	{
+		name: 'list_feedback',
+		description: 'Get all feedback for a specific introduction',
+		input_schema: {
+			type: 'object',
+			properties: {
+				introduction_id: { type: 'string', description: 'Introduction ID (UUID)' },
+			},
+			required: ['introduction_id'],
+		},
+	},
+	{
+		name: 'get_feedback',
+		description: 'Get a specific feedback record',
+		input_schema: {
+			type: 'object',
+			properties: {
+				id: { type: 'string', description: 'Feedback ID (UUID)' },
+			},
+			required: ['id'],
+		},
+	},
+]
+
+export type ToolName = (typeof toolDefinitions)[number]['name']

--- a/gateway/src/tools/executor.ts
+++ b/gateway/src/tools/executor.ts
@@ -1,0 +1,317 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export type ToolResult = {
+	content: string
+	isError?: boolean
+}
+
+export let executeTool = async (
+	supabaseClient: SupabaseClient,
+	userId: string,
+	toolName: string,
+	toolArgs: Record<string, unknown>
+): Promise<ToolResult> => {
+	try {
+		let result = await executeToolInner(supabaseClient, userId, toolName, toolArgs)
+		return { content: JSON.stringify(result, null, 2) }
+	} catch (error) {
+		let message = error instanceof Error ? error.message : 'Unknown error'
+		return { content: `Error: ${message}`, isError: true }
+	}
+}
+
+let executeToolInner = async (
+	supabaseClient: SupabaseClient,
+	userId: string,
+	toolName: string,
+	args: Record<string, unknown>
+): Promise<unknown> => {
+	switch (toolName) {
+		case 'add_person': {
+			requireString(args, 'name')
+			let { data, error } = await supabaseClient
+				.from('people')
+				.insert({ name: args.name, matchmaker_id: userId })
+				.select()
+				.single()
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'list_people': {
+			let { data, error } = await supabaseClient
+				.from('people')
+				.select('*')
+				.eq('matchmaker_id', userId)
+				.eq('active', true)
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'get_person': {
+			requireString(args, 'id')
+			let { data, error } = await supabaseClient
+				.from('people')
+				.select('*')
+				.eq('id', args.id)
+				.eq('matchmaker_id', userId)
+				.single()
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'update_person': {
+			requireString(args, 'id')
+			let { id, ...updates } = args
+			let { data, error } = await supabaseClient
+				.from('people')
+				.update(updates)
+				.eq('id', id)
+				.eq('matchmaker_id', userId)
+				.select()
+				.single()
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'create_introduction': {
+			requireString(args, 'person_a_id')
+			requireString(args, 'person_b_id')
+			return await createIntroduction(supabaseClient, userId, args as {
+				person_a_id: string
+				person_b_id: string
+				notes?: string
+			})
+		}
+
+		case 'list_introductions': {
+			let { data, error } = await supabaseClient
+				.from('introductions')
+				.select('*')
+				.or(`matchmaker_a_id.eq.${userId},matchmaker_b_id.eq.${userId}`)
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'update_introduction': {
+			requireString(args, 'id')
+			let { id, ...updates } = args
+			let { data, error } = await supabaseClient
+				.from('introductions')
+				.update(updates)
+				.eq('id', id)
+				.or(`matchmaker_a_id.eq.${userId},matchmaker_b_id.eq.${userId}`)
+				.select()
+				.maybeSingle()
+			if (error) throw new Error(error.message)
+			if (!data) throw new Error('Introduction not found')
+			return data
+		}
+
+		case 'find_matches': {
+			requireString(args, 'person_id')
+			// Verify person belongs to this matchmaker
+			let { data: person, error: personError } = await supabaseClient
+				.from('people')
+				.select('id')
+				.eq('id', args.person_id)
+				.eq('matchmaker_id', userId)
+				.maybeSingle()
+			if (personError) throw new Error(personError.message)
+			if (!person) throw new Error('Person not found')
+
+			// Fetch all active people (cross-matchmaker pool)
+			let { data: allPeople, error: peopleError } = await supabaseClient
+				.from('people')
+				.select('*')
+				.eq('active', true)
+			if (peopleError) throw new Error(peopleError.message)
+
+			// Fetch declined decisions to build exclusion set
+			let { data: decisions, error: decisionsError } = await supabaseClient
+				.from('match_decisions')
+				.select('candidate_id')
+				.eq('person_id', args.person_id)
+				.eq('matchmaker_id', userId)
+				.eq('decision', 'declined')
+			if (decisionsError) throw new Error(decisionsError.message)
+
+			let excludeIds = new Set(
+				(decisions || []).map((d: { candidate_id: string }) => d.candidate_id)
+			)
+
+			let eligible = (allPeople || []).filter(
+				(p: { id: string }) => !excludeIds.has(p.id) && p.id !== args.person_id
+			)
+
+			return eligible
+		}
+
+		case 'record_decision': {
+			requireString(args, 'person_id')
+			requireString(args, 'candidate_id')
+			requireString(args, 'decision')
+			if (args.decision !== 'accepted' && args.decision !== 'declined') {
+				throw new Error("decision must be 'accepted' or 'declined'")
+			}
+			// Verify person belongs to this matchmaker
+			let { data: person, error: personError } = await supabaseClient
+				.from('people')
+				.select('id')
+				.eq('id', args.person_id)
+				.eq('matchmaker_id', userId)
+				.maybeSingle()
+			if (personError) throw new Error(personError.message)
+			if (!person) throw new Error('Person not found')
+
+			let { data, error } = await supabaseClient
+				.from('match_decisions')
+				.insert({
+					matchmaker_id: userId,
+					person_id: args.person_id,
+					candidate_id: args.candidate_id,
+					decision: args.decision,
+					decline_reason: (args.decline_reason as string) || null,
+				})
+				.select()
+				.single()
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'list_decisions': {
+			requireString(args, 'person_id')
+			// Verify person belongs to this matchmaker
+			let { data: person, error: personError } = await supabaseClient
+				.from('people')
+				.select('id')
+				.eq('id', args.person_id)
+				.eq('matchmaker_id', userId)
+				.maybeSingle()
+			if (personError) throw new Error(personError.message)
+			if (!person) throw new Error('Person not found')
+
+			let { data, error } = await supabaseClient
+				.from('match_decisions')
+				.select('*')
+				.eq('person_id', args.person_id)
+				.eq('matchmaker_id', userId)
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'delete_person': {
+			requireString(args, 'id')
+			let { data, error } = await supabaseClient
+				.from('people')
+				.update({ active: false })
+				.eq('id', args.id)
+				.eq('matchmaker_id', userId)
+				.select()
+				.single()
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'get_introduction': {
+			requireString(args, 'id')
+			let { data, error } = await supabaseClient
+				.from('introductions')
+				.select('*')
+				.eq('id', args.id)
+				.or(`matchmaker_a_id.eq.${userId},matchmaker_b_id.eq.${userId}`)
+				.maybeSingle()
+			if (error) throw new Error(error.message)
+			if (!data) throw new Error('Introduction not found')
+			return data
+		}
+
+		case 'submit_feedback': {
+			requireString(args, 'introduction_id')
+			requireString(args, 'from_person_id')
+			requireString(args, 'content')
+			let { data, error } = await supabaseClient
+				.from('feedback')
+				.insert({
+					introduction_id: args.introduction_id,
+					from_person_id: args.from_person_id,
+					content: args.content,
+					sentiment: (args.sentiment as string) || null,
+				})
+				.select()
+				.single()
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'list_feedback': {
+			requireString(args, 'introduction_id')
+			let { data, error } = await supabaseClient
+				.from('feedback')
+				.select('*')
+				.eq('introduction_id', args.introduction_id)
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		case 'get_feedback': {
+			requireString(args, 'id')
+			let { data, error } = await supabaseClient
+				.from('feedback')
+				.select('*')
+				.eq('id', args.id)
+				.single()
+			if (error) throw new Error(error.message)
+			return data
+		}
+
+		default:
+			throw new Error(`Unknown tool: ${toolName}`)
+	}
+}
+
+let requireString = (args: Record<string, unknown>, field: string): void => {
+	if (!(field in args) || typeof args[field] !== 'string') {
+		throw new Error(`Invalid arguments: ${field} is required and must be a string`)
+	}
+}
+
+let createIntroduction = async (
+	supabaseClient: SupabaseClient,
+	userId: string,
+	args: { person_a_id: string; person_b_id: string; notes?: string }
+): Promise<unknown> => {
+	// Look up both people to get their matchmaker IDs
+	let { data: personA, error: personAError } = await supabaseClient
+		.from('people')
+		.select('id, matchmaker_id')
+		.eq('id', args.person_a_id)
+		.single()
+	if (personAError || !personA) throw new Error('Person A not found')
+
+	let { data: personB, error: personBError } = await supabaseClient
+		.from('people')
+		.select('id, matchmaker_id')
+		.eq('id', args.person_b_id)
+		.single()
+	if (personBError || !personB) throw new Error('Person B not found')
+
+	// Validate the requesting user owns at least one person
+	if (personA.matchmaker_id !== userId && personB.matchmaker_id !== userId) {
+		throw new Error('You must own at least one person in the introduction')
+	}
+
+	let { data, error } = await supabaseClient
+		.from('introductions')
+		.insert({
+			person_a_id: args.person_a_id,
+			person_b_id: args.person_b_id,
+			notes: args.notes || null,
+			matchmaker_a_id: personA.matchmaker_id,
+			matchmaker_b_id: personB.matchmaker_id,
+		})
+		.select()
+		.single()
+	if (error) throw new Error(error.message)
+	return data
+}

--- a/gateway/src/types/messages.ts
+++ b/gateway/src/types/messages.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export let inboundMessageSchema = z.object({
+	provider: z.string().min(1),
+	senderId: z.string().min(1),
+	text: z.string().min(1),
+	threadId: z.string().min(1),
+	timestamp: z.number(),
+})
+
+export type InboundMessage = z.infer<typeof inboundMessageSchema>
+
+export let outboundMessageSchema = z.object({
+	provider: z.string().min(1),
+	senderId: z.string().min(1),
+	threadId: z.string().min(1),
+	text: z.string().min(1),
+})
+
+export type OutboundMessage = z.infer<typeof outboundMessageSchema>

--- a/gateway/tests/adapters/test-adapter.test.ts
+++ b/gateway/tests/adapters/test-adapter.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'bun:test'
+import { TestAdapter } from '../../src/adapters/test/adapter'
+
+describe('TestAdapter', () => {
+	test('has provider set to "test"', () => {
+		let adapter = new TestAdapter()
+		expect(adapter.provider).toBe('test')
+	})
+
+	test('parseInbound creates InboundMessage from simple payload', async () => {
+		let adapter = new TestAdapter()
+
+		let msg = await adapter.parseInbound({ senderId: 'dev1', text: 'Hello' })
+
+		expect(msg.provider).toBe('test')
+		expect(msg.senderId).toBe('dev1')
+		expect(msg.text).toBe('Hello')
+		expect(msg.threadId).toBe('test:dev1')
+		expect(typeof msg.timestamp).toBe('number')
+	})
+
+	test('parseInbound throws on missing senderId', async () => {
+		let adapter = new TestAdapter()
+
+		await expect(adapter.parseInbound({ text: 'Hello' })).rejects.toThrow()
+	})
+
+	test('parseInbound throws on missing text', async () => {
+		let adapter = new TestAdapter()
+
+		await expect(adapter.parseInbound({ senderId: 'dev1' })).rejects.toThrow()
+	})
+
+	test('verifyWebhook always returns true', async () => {
+		let adapter = new TestAdapter()
+		let request = new Request('http://localhost/webhook/test')
+
+		let result = await adapter.verifyWebhook(request)
+
+		expect(result).toBe(true)
+	})
+
+	test('sendReply stores message in replies array', async () => {
+		let adapter = new TestAdapter()
+
+		await adapter.sendReply({
+			provider: 'test',
+			senderId: 'dev1',
+			threadId: 'test:dev1',
+			text: 'Response text',
+		})
+
+		expect(adapter.replies).toHaveLength(1)
+		expect(adapter.replies[0]!.text).toBe('Response text')
+		expect(adapter.replies[0]!.senderId).toBe('dev1')
+	})
+
+	test('sendReply accumulates multiple replies', async () => {
+		let adapter = new TestAdapter()
+
+		await adapter.sendReply({
+			provider: 'test',
+			senderId: 'dev1',
+			threadId: 'test:dev1',
+			text: 'First',
+		})
+		await adapter.sendReply({
+			provider: 'test',
+			senderId: 'dev1',
+			threadId: 'test:dev1',
+			text: 'Second',
+		})
+
+		expect(adapter.replies).toHaveLength(2)
+	})
+})

--- a/gateway/tests/config.test.ts
+++ b/gateway/tests/config.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from 'bun:test'
+import { configSchema } from '../src/config'
+
+describe('configSchema', () => {
+	test('parses valid config', () => {
+		let result = configSchema.parse({
+			SUPABASE_URL: 'https://example.supabase.co',
+			SUPABASE_SERVICE_ROLE_KEY: 'test-key',
+			ANTHROPIC_API_KEY: 'sk-ant-test',
+			PORT: '3001',
+		})
+
+		expect(result.SUPABASE_URL).toBe('https://example.supabase.co')
+		expect(result.SUPABASE_SERVICE_ROLE_KEY).toBe('test-key')
+		expect(result.ANTHROPIC_API_KEY).toBe('sk-ant-test')
+		expect(result.PORT).toBe(3001)
+	})
+
+	test('defaults PORT to 3001', () => {
+		let result = configSchema.parse({
+			SUPABASE_URL: 'https://example.supabase.co',
+			SUPABASE_SERVICE_ROLE_KEY: 'test-key',
+			ANTHROPIC_API_KEY: 'sk-ant-test',
+		})
+
+		expect(result.PORT).toBe(3001)
+	})
+
+	test('rejects missing SUPABASE_URL', () => {
+		expect(() =>
+			configSchema.parse({
+				SUPABASE_SERVICE_ROLE_KEY: 'test-key',
+				ANTHROPIC_API_KEY: 'sk-ant-test',
+			})
+		).toThrow()
+	})
+
+	test('rejects missing SUPABASE_SERVICE_ROLE_KEY', () => {
+		expect(() =>
+			configSchema.parse({
+				SUPABASE_URL: 'https://example.supabase.co',
+				ANTHROPIC_API_KEY: 'sk-ant-test',
+			})
+		).toThrow()
+	})
+
+	test('rejects missing ANTHROPIC_API_KEY', () => {
+		expect(() =>
+			configSchema.parse({
+				SUPABASE_URL: 'https://example.supabase.co',
+				SUPABASE_SERVICE_ROLE_KEY: 'test-key',
+			})
+		).toThrow()
+	})
+
+	test('rejects invalid SUPABASE_URL', () => {
+		expect(() =>
+			configSchema.parse({
+				SUPABASE_URL: 'not-a-url',
+				SUPABASE_SERVICE_ROLE_KEY: 'test-key',
+				ANTHROPIC_API_KEY: 'sk-ant-test',
+			})
+		).toThrow()
+	})
+
+	test('coerces PORT string to number', () => {
+		let result = configSchema.parse({
+			SUPABASE_URL: 'https://example.supabase.co',
+			SUPABASE_SERVICE_ROLE_KEY: 'test-key',
+			ANTHROPIC_API_KEY: 'sk-ant-test',
+			PORT: '8080',
+		})
+
+		expect(result.PORT).toBe(8080)
+	})
+})

--- a/gateway/tests/core/ai.test.ts
+++ b/gateway/tests/core/ai.test.ts
@@ -1,0 +1,179 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test'
+import { processMessage, type MessageCreateFn, type Deps } from '../../src/core/ai'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import type Anthropic from '@anthropic-ai/sdk'
+
+let createMockSupabase = (): SupabaseClient => ({}) as unknown as SupabaseClient
+
+let savedMessages: { threadId: string; role: string; content: unknown }[] = []
+
+let mockDeps = (): Deps => ({
+	save: mock(async (_client, params) => {
+		savedMessages.push(params)
+		return {
+			...params,
+			id: 'msg-1',
+			thread_id: params.threadId,
+			created_at: new Date().toISOString(),
+		} as any
+	}),
+	getHistory: mock(async () => []),
+	executeTool: mock(async () => ({
+		content: JSON.stringify([{ id: 'p1', name: 'Alice' }]),
+	})),
+})
+
+let createMockCreateMessage = (
+	responses: Partial<Anthropic.Message>[]
+): MessageCreateFn => {
+	let callIndex = 0
+	return mock(async (_params: Anthropic.MessageCreateParamsNonStreaming) => {
+		let response = responses[callIndex] ?? responses[responses.length - 1]
+		callIndex++
+		return {
+			id: 'msg-1',
+			type: 'message' as const,
+			role: 'assistant' as const,
+			model: 'claude-sonnet-4-20250514',
+			usage: {
+				input_tokens: 100,
+				output_tokens: 50,
+				cache_read_input_tokens: 0,
+				cache_creation_input_tokens: 0,
+			},
+			stop_reason: 'end_turn',
+			content: [],
+			...response,
+		} as Anthropic.Message
+	})
+}
+
+beforeEach(() => {
+	savedMessages = []
+})
+
+describe('processMessage', () => {
+	test('returns text response for simple message', async () => {
+		let createMessage = createMockCreateMessage([
+			{
+				stop_reason: 'end_turn',
+				content: [{ type: 'text', text: 'Hello! How can I help you find a match?' }],
+			},
+		])
+		let deps = { ...mockDeps(), createMessage }
+
+		let result = await processMessage({
+			text: 'Hi there',
+			threadId: 'test:123',
+			userId: 'user-1',
+			supabaseClient: createMockSupabase(),
+			deps,
+		})
+
+		expect(result).toBe('Hello! How can I help you find a match?')
+	})
+
+	test('saves user and assistant messages to conversation store', async () => {
+		let createMessage = createMockCreateMessage([
+			{
+				stop_reason: 'end_turn',
+				content: [{ type: 'text', text: 'Hi!' }],
+			},
+		])
+		let deps = { ...mockDeps(), createMessage }
+
+		await processMessage({
+			text: 'Hi there',
+			threadId: 'test:123',
+			userId: 'user-1',
+			supabaseClient: createMockSupabase(),
+			deps,
+		})
+
+		expect(savedMessages).toHaveLength(2)
+		expect(savedMessages[0]!.role).toBe('user')
+		expect(savedMessages[0]!.content).toBe('Hi there')
+		expect(savedMessages[1]!.role).toBe('assistant')
+		expect(savedMessages[1]!.content).toBe('Hi!')
+	})
+
+	test('calls Anthropic API with system prompt and tools', async () => {
+		let createMessage = createMockCreateMessage([
+			{
+				stop_reason: 'end_turn',
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+		])
+		let deps = { ...mockDeps(), createMessage }
+
+		await processMessage({
+			text: 'Hello',
+			threadId: 'test:456',
+			userId: 'user-1',
+			supabaseClient: createMockSupabase(),
+			deps,
+		})
+
+		expect(createMessage).toHaveBeenCalled()
+		let callArgs = (createMessage as ReturnType<typeof mock>).mock.calls[0]![0] as Record<
+			string,
+			unknown
+		>
+		expect(callArgs.system).toBeDefined()
+		expect(callArgs.tools).toBeDefined()
+		expect(callArgs.messages).toBeDefined()
+	})
+
+	test('handles tool-calling loop', async () => {
+		let createMessage = createMockCreateMessage([
+			{
+				stop_reason: 'tool_use',
+				content: [
+					{ type: 'text', text: 'Let me look up your people.' },
+					{
+						type: 'tool_use',
+						id: 'call-1',
+						name: 'list_people',
+						input: {},
+					},
+				],
+			},
+			{
+				stop_reason: 'end_turn',
+				content: [{ type: 'text', text: 'You have 1 person: Alice.' }],
+			},
+		])
+		let deps = { ...mockDeps(), createMessage }
+
+		let result = await processMessage({
+			text: 'List my people',
+			threadId: 'test:789',
+			userId: 'user-1',
+			supabaseClient: createMockSupabase(),
+			deps,
+		})
+
+		expect(result).toBe('You have 1 person: Alice.')
+		expect(createMessage).toHaveBeenCalledTimes(2)
+	})
+
+	test('handles response with no text blocks', async () => {
+		let createMessage = createMockCreateMessage([
+			{
+				stop_reason: 'end_turn',
+				content: [],
+			},
+		])
+		let deps = { ...mockDeps(), createMessage }
+
+		let result = await processMessage({
+			text: 'Hi',
+			threadId: 'test:empty',
+			userId: 'user-1',
+			supabaseClient: createMockSupabase(),
+			deps,
+		})
+
+		expect(result).toBe('')
+	})
+})

--- a/gateway/tests/health.test.ts
+++ b/gateway/tests/health.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect } from 'bun:test'
+import { app } from '../src/index'
+
+describe('GET /health', () => {
+	test('returns 200 with ok status', async () => {
+		let res = await app.fetch(new Request('http://localhost/health'))
+
+		expect(res.status).toBe(200)
+
+		let body = await res.json()
+		expect(body.status).toBe('ok')
+	})
+})
+
+describe('unknown routes', () => {
+	test('returns 404 for unknown path', async () => {
+		let res = await app.fetch(new Request('http://localhost/nonexistent'))
+
+		expect(res.status).toBe(404)
+	})
+})

--- a/gateway/tests/integration/test-adapter-flow.test.ts
+++ b/gateway/tests/integration/test-adapter-flow.test.ts
@@ -1,0 +1,207 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test'
+import { Hono } from 'hono'
+import { createWebhookRoutes } from '../../src/router/webhooks'
+import * as registry from '../../src/router/registry'
+import { TestAdapter } from '../../src/adapters/test/adapter'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+let savedMessages: { threadId: string; role: string; content: unknown }[] = []
+let resolvedUsers: { provider: string; senderId: string }[] = []
+
+let createMockSupabase = (): SupabaseClient => ({}) as unknown as SupabaseClient
+
+let mockSave = () =>
+	mock(async (_client: unknown, params: any) => {
+		savedMessages.push(params)
+		return { ...params, id: 'msg-1', created_at: new Date().toISOString() }
+	})
+
+let mockResolveOrCreate = () =>
+	mock(async (_client: unknown, provider: string, senderId: string) => {
+		resolvedUsers.push({ provider, senderId })
+		return 'resolved-user-id'
+	})
+
+let simpleResponse = (text: string) => ({
+	id: 'msg-1',
+	type: 'message' as const,
+	role: 'assistant' as const,
+	model: 'claude-sonnet-4-20250514',
+	usage: { input_tokens: 10, output_tokens: 20, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+	stop_reason: 'end_turn' as const,
+	content: [{ type: 'text' as const, text }],
+})
+
+beforeEach(() => {
+	registry.clear()
+	savedMessages = []
+	resolvedUsers = []
+})
+
+describe('Integration: Test adapter full message loop', () => {
+	test('first message from new user flows through entire pipeline', async () => {
+		let adapter = new TestAdapter()
+		registry.register(adapter)
+
+		let app = new Hono()
+		app.route(
+			'/webhook',
+			createWebhookRoutes({
+				supabaseClient: createMockSupabase(),
+				resolveOrCreate: mockResolveOrCreate(),
+				aiDeps: {
+					createMessage: mock(async () => simpleResponse('Welcome to matchmaker!')),
+					save: mockSave(),
+					getHistory: mock(async () => []),
+					executeTool: mock(async () => ({ content: '[]' })),
+				},
+			})
+		)
+
+		let res = await app.fetch(
+			new Request('http://localhost/webhook/test', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ senderId: 'new-user-1', text: 'Hi, I need a matchmaker' }),
+			})
+		)
+
+		expect(res.status).toBe(200)
+
+		// User was resolved
+		expect(resolvedUsers).toHaveLength(1)
+		expect(resolvedUsers[0]!.provider).toBe('test')
+		expect(resolvedUsers[0]!.senderId).toBe('new-user-1')
+
+		// Conversation was saved (user + assistant)
+		expect(savedMessages).toHaveLength(2)
+		expect(savedMessages[0]!.role).toBe('user')
+		expect(savedMessages[0]!.content).toBe('Hi, I need a matchmaker')
+		expect(savedMessages[0]!.threadId).toBe('test:new-user-1')
+		expect(savedMessages[1]!.role).toBe('assistant')
+		expect(savedMessages[1]!.content).toBe('Welcome to matchmaker!')
+
+		// Reply was sent via adapter
+		expect(adapter.replies).toHaveLength(1)
+		expect(adapter.replies[0]!.text).toBe('Welcome to matchmaker!')
+		expect(adapter.replies[0]!.senderId).toBe('new-user-1')
+	})
+
+	test('tool-calling flow executes tool and returns final response', async () => {
+		let adapter = new TestAdapter()
+		registry.register(adapter)
+
+		let callCount = 0
+		let app = new Hono()
+		app.route(
+			'/webhook',
+			createWebhookRoutes({
+				supabaseClient: createMockSupabase(),
+				resolveOrCreate: mockResolveOrCreate(),
+				aiDeps: {
+					createMessage: mock(async () => {
+						callCount++
+						if (callCount === 1) {
+							return {
+								id: 'msg-1',
+								type: 'message' as const,
+								role: 'assistant' as const,
+								model: 'claude-sonnet-4-20250514',
+								usage: { input_tokens: 10, output_tokens: 20, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+								stop_reason: 'tool_use' as const,
+								content: [
+									{ type: 'tool_use' as const, id: 'call-1', name: 'list_people', input: {} },
+								],
+							}
+						}
+						return simpleResponse('You have 2 people: Alice and Bob.')
+					}),
+					save: mockSave(),
+					getHistory: mock(async () => []),
+					executeTool: mock(async () => ({
+						content: JSON.stringify([
+							{ id: 'p1', name: 'Alice' },
+							{ id: 'p2', name: 'Bob' },
+						]),
+					})),
+				},
+			})
+		)
+
+		let res = await app.fetch(
+			new Request('http://localhost/webhook/test', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ senderId: 'user-2', text: 'Show my people' }),
+			})
+		)
+
+		expect(res.status).toBe(200)
+		expect(adapter.replies).toHaveLength(1)
+		expect(adapter.replies[0]!.text).toBe('You have 2 people: Alice and Bob.')
+		expect(callCount).toBe(2)
+	})
+
+	test('multiple providers use same pipeline', async () => {
+		let testAdapter = new TestAdapter()
+		registry.register(testAdapter)
+
+		let otherReplies: { text: string }[] = []
+		registry.register({
+			provider: 'other',
+			parseInbound: mock(async (raw: unknown) => {
+				let body = raw as { id: string; msg: string }
+				return {
+					provider: 'other',
+					senderId: body.id,
+					text: body.msg,
+					threadId: `other:${body.id}`,
+					timestamp: Date.now(),
+				}
+			}),
+			sendReply: mock(async msg => {
+				otherReplies.push({ text: msg.text })
+			}),
+			verifyWebhook: mock(async () => true),
+		})
+
+		let app = new Hono()
+		app.route(
+			'/webhook',
+			createWebhookRoutes({
+				supabaseClient: createMockSupabase(),
+				resolveOrCreate: mockResolveOrCreate(),
+				aiDeps: {
+					createMessage: mock(async () => simpleResponse('Processed!')),
+					save: mockSave(),
+					getHistory: mock(async () => []),
+					executeTool: mock(async () => ({ content: '[]' })),
+				},
+			})
+		)
+
+		await app.fetch(
+			new Request('http://localhost/webhook/test', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ senderId: 'user-a', text: 'Hello from test' }),
+			})
+		)
+
+		await app.fetch(
+			new Request('http://localhost/webhook/other', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ id: 'user-b', msg: 'Hello from other' }),
+			})
+		)
+
+		expect(testAdapter.replies).toHaveLength(1)
+		expect(otherReplies).toHaveLength(1)
+
+		// Both went through same pipeline (4 saved: 2 user + 2 assistant)
+		expect(savedMessages).toHaveLength(4)
+		expect(savedMessages[0]!.threadId).toBe('test:user-a')
+		expect(savedMessages[2]!.threadId).toBe('other:user-b')
+	})
+})

--- a/gateway/tests/router/webhooks.test.ts
+++ b/gateway/tests/router/webhooks.test.ts
@@ -1,0 +1,135 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test'
+import { Hono } from 'hono'
+import { createWebhookRoutes } from '../../src/router/webhooks'
+import * as registry from '../../src/router/registry'
+import type { ChatProviderAdapter } from '../../src/adapters/types'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+let createMockAdapter = (overrides: Partial<ChatProviderAdapter> = {}): ChatProviderAdapter => ({
+	provider: 'test',
+	parseInbound: mock(async (raw: unknown) => {
+		let body = raw as { senderId: string; text: string }
+		return {
+			provider: 'test',
+			senderId: body.senderId,
+			text: body.text,
+			threadId: `test:${body.senderId}`,
+			timestamp: Date.now(),
+		}
+	}),
+	sendReply: mock(async () => {}),
+	verifyWebhook: mock(async () => true),
+	...overrides,
+})
+
+let createMockSupabase = (): SupabaseClient => ({}) as unknown as SupabaseClient
+
+let createApp = () => {
+	let app = new Hono()
+	app.route(
+		'/webhook',
+		createWebhookRoutes({
+			supabaseClient: createMockSupabase(),
+			resolveOrCreate: mock(async () => 'resolved-user-id'),
+			aiDeps: {
+				createMessage: mock(async () => ({
+					id: 'msg-1',
+					type: 'message' as const,
+					role: 'assistant' as const,
+					model: 'claude-sonnet-4-20250514',
+					usage: { input_tokens: 10, output_tokens: 20, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+					stop_reason: 'end_turn' as const,
+					content: [{ type: 'text' as const, text: 'AI response' }],
+				})),
+				save: mock(async (_client: unknown, params: any) => ({
+					...params,
+					id: 'msg-1',
+					created_at: new Date().toISOString(),
+				})),
+				getHistory: mock(async () => []),
+				executeTool: mock(async () => ({ content: '[]' })),
+			},
+		})
+	)
+	return app
+}
+
+beforeEach(() => {
+	registry.clear()
+})
+
+describe('POST /webhook/:provider', () => {
+	test('routes to registered adapter and returns ok', async () => {
+		let adapter = createMockAdapter()
+		registry.register(adapter)
+		let app = createApp()
+
+		let res = await app.fetch(
+			new Request('http://localhost/webhook/test', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ senderId: 'user1', text: 'Hello' }),
+			})
+		)
+
+		expect(res.status).toBe(200)
+		let body = await res.json()
+		expect(body.ok).toBe(true)
+		expect(adapter.parseInbound).toHaveBeenCalled()
+		expect(adapter.sendReply).toHaveBeenCalled()
+	})
+
+	test('returns 404 for unknown provider', async () => {
+		let app = createApp()
+
+		let res = await app.fetch(
+			new Request('http://localhost/webhook/unknown', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ text: 'Hello' }),
+			})
+		)
+
+		expect(res.status).toBe(404)
+		let body = await res.json()
+		expect(body.error).toContain('unknown')
+	})
+
+	test('returns 401 when webhook verification fails', async () => {
+		let adapter = createMockAdapter({
+			verifyWebhook: mock(async () => false),
+		})
+		registry.register(adapter)
+		let app = createApp()
+
+		let res = await app.fetch(
+			new Request('http://localhost/webhook/test', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ senderId: 'user1', text: 'Hello' }),
+			})
+		)
+
+		expect(res.status).toBe(401)
+	})
+
+	test('returns 400 when adapter parse fails', async () => {
+		let adapter = createMockAdapter({
+			parseInbound: mock(async () => {
+				throw new Error('bad payload')
+			}),
+		})
+		registry.register(adapter)
+		let app = createApp()
+
+		let res = await app.fetch(
+			new Request('http://localhost/webhook/test', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ bad: 'data' }),
+			})
+		)
+
+		expect(res.status).toBe(400)
+	})
+})

--- a/gateway/tests/services/user-mapping.test.ts
+++ b/gateway/tests/services/user-mapping.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect, mock } from 'bun:test'
+import { resolveOrCreate } from '../../src/services/user-mapping'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+let createMockClient = (overrides: {
+	selectResult?: { data: unknown; error: unknown }
+	createUserResult?: { data: unknown; error: unknown }
+	insertResult?: { data: unknown; error: unknown }
+} = {}): SupabaseClient => {
+	let fromMock = mock((_table: string) => ({
+		select: mock(() => ({
+			eq: mock(() => ({
+				eq: mock(() => ({
+					maybeSingle: mock(async () =>
+						overrides.selectResult ?? { data: null, error: null }
+					),
+				})),
+			})),
+		})),
+		insert: mock(() => ({
+			select: mock(() => ({
+				single: mock(async () =>
+					overrides.insertResult ?? {
+						data: {
+							id: 'mapping-1',
+							user_id: 'new-user-id',
+							provider: 'telegram',
+							sender_id: '12345',
+						},
+						error: null,
+					}
+				),
+			})),
+		})),
+	}))
+
+	let authMock = {
+		admin: {
+			createUser: mock(async () =>
+				overrides.createUserResult ?? {
+					data: { user: { id: 'new-user-id' } },
+					error: null,
+				}
+			),
+		},
+	}
+
+	return { from: fromMock, auth: authMock } as unknown as SupabaseClient
+}
+
+describe('resolveOrCreate', () => {
+	test('returns existing userId when mapping exists', async () => {
+		let client = createMockClient({
+			selectResult: {
+				data: { user_id: 'existing-user-id' },
+				error: null,
+			},
+		})
+
+		let userId = await resolveOrCreate(client, 'telegram', '12345')
+
+		expect(userId).toBe('existing-user-id')
+		expect(client.auth.admin.createUser).not.toHaveBeenCalled()
+	})
+
+	test('creates new user and mapping when none exists', async () => {
+		let client = createMockClient()
+
+		let userId = await resolveOrCreate(client, 'telegram', '12345')
+
+		expect(userId).toBe('new-user-id')
+		expect(client.auth.admin.createUser).toHaveBeenCalled()
+		expect(client.from).toHaveBeenCalledWith('user_provider_mappings')
+	})
+
+	test('throws when user creation fails', async () => {
+		let client = createMockClient({
+			createUserResult: {
+				data: { user: null },
+				error: { message: 'creation failed' },
+			},
+		})
+
+		await expect(resolveOrCreate(client, 'telegram', '12345')).rejects.toThrow(
+			'Failed to create user'
+		)
+	})
+
+	test('throws when mapping insert fails', async () => {
+		let client = createMockClient({
+			insertResult: {
+				data: null,
+				error: { message: 'unique constraint' },
+			},
+		})
+
+		await expect(resolveOrCreate(client, 'telegram', '12345')).rejects.toThrow(
+			'Failed to create user provider mapping'
+		)
+	})
+
+	test('throws when mapping lookup fails', async () => {
+		let client = createMockClient({
+			selectResult: {
+				data: null,
+				error: { message: 'db error' },
+			},
+		})
+
+		await expect(resolveOrCreate(client, 'telegram', '12345')).rejects.toThrow(
+			'Failed to look up user provider mapping'
+		)
+	})
+})

--- a/gateway/tests/store/conversations.test.ts
+++ b/gateway/tests/store/conversations.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, mock } from 'bun:test'
+import { save, getHistory } from '../../src/store/conversations'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+let createMockClient = (overrides: {
+	insertResult?: { data: unknown; error: unknown }
+	selectResult?: { data: unknown; error: unknown }
+} = {}): SupabaseClient => {
+	let defaultInsertResult = {
+		data: {
+			id: 'msg-1',
+			thread_id: 'test:123',
+			role: 'user',
+			content: 'Hello',
+			created_at: '2026-03-27T00:00:00Z',
+		},
+		error: null,
+	}
+
+	let defaultSelectResult = {
+		data: [
+			{ role: 'user', content: 'Hello', created_at: '2026-03-27T00:00:00Z' },
+			{ role: 'assistant', content: 'Hi!', created_at: '2026-03-27T00:00:01Z' },
+		],
+		error: null,
+	}
+
+	let insertResult = overrides.insertResult ?? defaultInsertResult
+	let selectResult = overrides.selectResult ?? defaultSelectResult
+
+	let fromMock = mock((_table: string) => ({
+		insert: mock(() => ({
+			select: mock(() => ({
+				single: mock(async () => insertResult),
+			})),
+		})),
+		select: mock(() => ({
+			eq: mock(() => ({
+				order: mock(() => ({
+					limit: mock(async () => selectResult),
+				})),
+			})),
+		})),
+	}))
+
+	return { from: fromMock } as unknown as SupabaseClient
+}
+
+describe('save', () => {
+	test('inserts a message into conversations table', async () => {
+		let client = createMockClient()
+
+		let result = await save(client, {
+			threadId: 'test:123',
+			role: 'user',
+			content: 'Hello',
+		})
+
+		expect(result.thread_id).toBe('test:123')
+		expect(client.from).toHaveBeenCalledWith('conversations')
+	})
+
+	test('saves with optional provider and senderId', async () => {
+		let client = createMockClient({
+			insertResult: {
+				data: {
+					id: 'msg-2',
+					thread_id: 'telegram:456',
+					role: 'user',
+					content: 'Hello',
+					provider: 'telegram',
+					sender_id: '456',
+					created_at: '2026-03-27T00:00:00Z',
+				},
+				error: null,
+			},
+		})
+
+		let result = await save(client, {
+			threadId: 'telegram:456',
+			role: 'user',
+			content: 'Hello',
+			provider: 'telegram',
+			senderId: '456',
+		})
+
+		expect(result.thread_id).toBe('telegram:456')
+	})
+
+	test('throws on insert error', async () => {
+		let client = createMockClient({
+			insertResult: { data: null, error: { message: 'insert failed' } },
+		})
+
+		await expect(
+			save(client, { threadId: 'test:123', role: 'user', content: 'Hello' })
+		).rejects.toThrow('Failed to save conversation message')
+	})
+})
+
+describe('getHistory', () => {
+	test('returns messages ordered by created_at', async () => {
+		let client = createMockClient()
+
+		let history = await getHistory(client, 'test:123', 10)
+
+		expect(history).toHaveLength(2)
+		expect(history[0]!.role).toBe('user')
+		expect(history[1]!.role).toBe('assistant')
+		expect(client.from).toHaveBeenCalledWith('conversations')
+	})
+
+	test('returns empty array for empty thread', async () => {
+		let client = createMockClient({
+			selectResult: { data: [], error: null },
+		})
+
+		let history = await getHistory(client, 'test:new', 10)
+
+		expect(history).toHaveLength(0)
+	})
+
+	test('throws on select error', async () => {
+		let client = createMockClient({
+			selectResult: { data: null, error: { message: 'select failed' } },
+		})
+
+		await expect(getHistory(client, 'test:123', 10)).rejects.toThrow(
+			'Failed to get conversation history'
+		)
+	})
+})

--- a/gateway/tests/tools/executor.test.ts
+++ b/gateway/tests/tools/executor.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect, mock } from 'bun:test'
+import { executeTool } from '../../src/tools/executor'
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+// Helper to create a mock Supabase client with chainable query builder
+let createMockClient = (
+	fromHandler: (table: string) => unknown
+): SupabaseClient => {
+	return { from: mock(fromHandler) } as unknown as SupabaseClient
+}
+
+// Helper for simple insert → select → single chains
+let mockInsertChain = (result: { data: unknown; error: unknown }) => ({
+	insert: mock(() => ({
+		select: mock(() => ({
+			single: mock(async () => result),
+		})),
+	})),
+})
+
+// Helper for simple select chains with eq
+let mockSelectEqChain = (result: { data: unknown; error: unknown }) => ({
+	select: mock(() => ({
+		eq: mock(() => ({
+			eq: mock(() => result),
+			single: mock(async () => result),
+		})),
+	})),
+})
+
+describe('executeTool', () => {
+	test('add_person inserts and returns person data', async () => {
+		let mockPerson = { id: 'person-1', name: 'Alice', matchmaker_id: 'user-1' }
+		let client = createMockClient(() => mockInsertChain({ data: mockPerson, error: null }))
+
+		let result = await executeTool(client, 'user-1', 'add_person', { name: 'Alice' })
+
+		expect(result.isError).toBeUndefined()
+		expect(JSON.parse(result.content)).toEqual(mockPerson)
+		expect(client.from).toHaveBeenCalledWith('people')
+	})
+
+	test('add_person returns error when name missing', async () => {
+		let client = createMockClient(() => ({}))
+
+		let result = await executeTool(client, 'user-1', 'add_person', {})
+
+		expect(result.isError).toBe(true)
+		expect(result.content).toContain('name is required')
+	})
+
+	test('list_people returns active people for matchmaker', async () => {
+		let mockPeople = [{ id: 'p1', name: 'Alice' }, { id: 'p2', name: 'Bob' }]
+		let client = createMockClient(() => ({
+			select: mock(() => ({
+				eq: mock(() => ({
+					eq: mock(async () => ({ data: mockPeople, error: null })),
+				})),
+			})),
+		}))
+
+		let result = await executeTool(client, 'user-1', 'list_people', {})
+
+		expect(result.isError).toBeUndefined()
+		expect(JSON.parse(result.content)).toEqual(mockPeople)
+	})
+
+	test('get_person returns single person', async () => {
+		let mockPerson = { id: 'p1', name: 'Alice' }
+		let client = createMockClient(() => ({
+			select: mock(() => ({
+				eq: mock(() => ({
+					eq: mock(() => ({
+						single: mock(async () => ({ data: mockPerson, error: null })),
+					})),
+				})),
+			})),
+		}))
+
+		let result = await executeTool(client, 'user-1', 'get_person', { id: 'p1' })
+
+		expect(result.isError).toBeUndefined()
+		expect(JSON.parse(result.content)).toEqual(mockPerson)
+	})
+
+	test('delete_person soft-deletes by setting active=false', async () => {
+		let mockPerson = { id: 'p1', name: 'Alice', active: false }
+		let client = createMockClient(() => ({
+			update: mock(() => ({
+				eq: mock(() => ({
+					eq: mock(() => ({
+						select: mock(() => ({
+							single: mock(async () => ({ data: mockPerson, error: null })),
+						})),
+					})),
+				})),
+			})),
+		}))
+
+		let result = await executeTool(client, 'user-1', 'delete_person', { id: 'p1' })
+
+		expect(result.isError).toBeUndefined()
+		expect(JSON.parse(result.content).active).toBe(false)
+	})
+
+	test('submit_feedback inserts feedback record', async () => {
+		let mockFeedback = { id: 'fb-1', content: 'Great match!' }
+		let client = createMockClient(() => mockInsertChain({ data: mockFeedback, error: null }))
+
+		let result = await executeTool(client, 'user-1', 'submit_feedback', {
+			introduction_id: 'intro-1',
+			from_person_id: 'p1',
+			content: 'Great match!',
+		})
+
+		expect(result.isError).toBeUndefined()
+		expect(JSON.parse(result.content)).toEqual(mockFeedback)
+	})
+
+	test('submit_feedback returns error when content missing', async () => {
+		let client = createMockClient(() => ({}))
+
+		let result = await executeTool(client, 'user-1', 'submit_feedback', {
+			introduction_id: 'intro-1',
+			from_person_id: 'p1',
+		})
+
+		expect(result.isError).toBe(true)
+		expect(result.content).toContain('content is required')
+	})
+
+	test('unknown tool returns error', async () => {
+		let client = createMockClient(() => ({}))
+
+		let result = await executeTool(client, 'user-1', 'nonexistent_tool', {})
+
+		expect(result.isError).toBe(true)
+		expect(result.content).toContain('Unknown tool')
+	})
+
+	test('database error is wrapped in error result', async () => {
+		let client = createMockClient(() => ({
+			select: mock(() => ({
+				eq: mock(() => ({
+					eq: mock(async () => ({ data: null, error: { message: 'connection lost' } })),
+				})),
+			})),
+		}))
+
+		let result = await executeTool(client, 'user-1', 'list_people', {})
+
+		expect(result.isError).toBe(true)
+		expect(result.content).toContain('connection lost')
+	})
+})

--- a/gateway/tests/types/messages.test.ts
+++ b/gateway/tests/types/messages.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from 'bun:test'
+import { inboundMessageSchema, outboundMessageSchema } from '../../src/types/messages'
+
+describe('InboundMessage schema', () => {
+	test('validates a complete inbound message', () => {
+		let result = inboundMessageSchema.parse({
+			provider: 'telegram',
+			senderId: '12345',
+			text: 'Hello',
+			threadId: 'telegram:12345',
+			timestamp: Date.now(),
+		})
+
+		expect(result.provider).toBe('telegram')
+		expect(result.senderId).toBe('12345')
+		expect(result.text).toBe('Hello')
+		expect(result.threadId).toBe('telegram:12345')
+		expect(typeof result.timestamp).toBe('number')
+	})
+
+	test('rejects missing text field', () => {
+		expect(() =>
+			inboundMessageSchema.parse({
+				provider: 'telegram',
+				senderId: '12345',
+				threadId: 'telegram:12345',
+				timestamp: Date.now(),
+			})
+		).toThrow()
+	})
+
+	test('rejects missing provider', () => {
+		expect(() =>
+			inboundMessageSchema.parse({
+				senderId: '12345',
+				text: 'Hello',
+				threadId: 'telegram:12345',
+				timestamp: Date.now(),
+			})
+		).toThrow()
+	})
+
+	test('rejects missing senderId', () => {
+		expect(() =>
+			inboundMessageSchema.parse({
+				provider: 'telegram',
+				text: 'Hello',
+				threadId: 'telegram:12345',
+				timestamp: Date.now(),
+			})
+		).toThrow()
+	})
+
+	test('rejects missing threadId', () => {
+		expect(() =>
+			inboundMessageSchema.parse({
+				provider: 'telegram',
+				senderId: '12345',
+				text: 'Hello',
+				timestamp: Date.now(),
+			})
+		).toThrow()
+	})
+
+	test('rejects missing timestamp', () => {
+		expect(() =>
+			inboundMessageSchema.parse({
+				provider: 'telegram',
+				senderId: '12345',
+				text: 'Hello',
+				threadId: 'telegram:12345',
+			})
+		).toThrow()
+	})
+})
+
+describe('OutboundMessage schema', () => {
+	test('validates a complete outbound message', () => {
+		let result = outboundMessageSchema.parse({
+			provider: 'telegram',
+			senderId: '12345',
+			threadId: 'telegram:12345',
+			text: 'Hi there!',
+		})
+
+		expect(result.provider).toBe('telegram')
+		expect(result.text).toBe('Hi there!')
+	})
+
+	test('rejects missing text', () => {
+		expect(() =>
+			outboundMessageSchema.parse({
+				provider: 'telegram',
+				senderId: '12345',
+				threadId: 'telegram:12345',
+			})
+		).toThrow()
+	})
+
+	test('rejects missing provider', () => {
+		expect(() =>
+			outboundMessageSchema.parse({
+				senderId: '12345',
+				threadId: 'telegram:12345',
+				text: 'Hi',
+			})
+		).toThrow()
+	})
+})

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -1,0 +1,26 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ESNext"],
+		"types": ["bun-types"],
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"allowJs": true,
+		"noUncheckedIndexedAccess": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noFallthroughCasesInSwitch": true,
+		"outDir": "./dist",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["./src/*"]
+		}
+	},
+	"include": ["src/**/*", "tests/**/*", "**/*.test.ts"],
+	"exclude": ["node_modules", "dist"]
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
 	"version": "0.1.0",
 	"private": true,
 	"scripts": {
-		"test": "bun run test:backend && bun run test:mcp",
+		"test": "bun run test:backend && bun run test:mcp && bun run test:gateway",
 		"test:backend": "cd backend && bun test",
 		"test:mcp": "cd mcp-server && bun run test",
+		"test:gateway": "cd gateway && bun test",
 		"get-jwt": "bun run scripts/get-jwt.ts"
 	},
 	"dependencies": {

--- a/supabase/migrations/20260327000000_add_user_provider_mappings.sql
+++ b/supabase/migrations/20260327000000_add_user_provider_mappings.sql
@@ -1,0 +1,12 @@
+-- User provider mappings: resolve chat platform IDs to Supabase auth users
+CREATE TABLE user_provider_mappings (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID NOT NULL REFERENCES auth.users(id),
+  provider   TEXT NOT NULL,
+  sender_id  TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(provider, sender_id)
+);
+
+-- Enable RLS (service role bypasses, but defense-in-depth)
+ALTER TABLE user_provider_mappings ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/20260327100000_add_conversations.sql
+++ b/supabase/migrations/20260327100000_add_conversations.sql
@@ -1,0 +1,15 @@
+-- Conversation store: server-side message history for gateway
+CREATE TABLE conversations (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id  TEXT NOT NULL,
+  role       TEXT NOT NULL CHECK (role IN ('user', 'assistant')),
+  content    JSONB NOT NULL,
+  provider   TEXT,
+  sender_id  TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_conversations_thread ON conversations(thread_id, created_at);
+
+-- Enable RLS (service role bypasses, but defense-in-depth)
+ALTER TABLE conversations ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

- Scaffolds `gateway/` package with Hono server, Zod-validated config, and Anthropic SDK
- Defines normalized `InboundMessage`/`OutboundMessage` types and `ChatProviderAdapter` interface
- Adds `user_provider_mappings` table + `resolveOrCreate()` service for auto-provisioning chat users
- Adds `conversations` table (JSONB content) + store module for server-side message history
- Extracts all 15 matchmaker tools from `backend/src/routes/mcp.ts` into a gateway tool executor with direct Supabase calls
- Implements headless AI core with Anthropic SDK tool-calling loop (`processMessage()`)
- Adds chat router dispatching `POST /webhook/:provider` to registered adapters
- Implements `TestAdapter` for local dev and curl-based testing
- 57 gateway tests including 3 end-to-end integration tests (393 total across monorepo)

## Commits (9 conventional)

1. `feat(gateway): scaffold gateway package with Hono server and validated config`
2. `feat(gateway): define message types and ChatProviderAdapter interface`
3. `feat(gateway): add user provider mapping service with Supabase migration`
4. `feat(gateway): add conversation store with Supabase persistence`
5. `feat(gateway): add tool executor with direct Supabase calls`
6. `feat(gateway): implement headless AI core with Anthropic SDK tool-calling loop`
7. `feat(gateway): add chat router with provider webhook dispatch`
8. `feat(gateway): implement test adapter for local development`
9. `test(gateway): add end-to-end integration tests for full message loop`

## Open questions from implementation plan

1. **Deployment target** — Where does the gateway run? (Fly.io, Railway, VPS)
2. **Rate limiting** — Gateway-level per-user or rely on provider limits?
3. **Message queue** — Synchronous for v1, defer async until scale issues?

## Test plan

- [ ] `bun run test` — all 393 tests pass (209 backend + 127 mcp + 57 gateway)
- [ ] `supabase db push` — verify `user_provider_mappings` and `conversations` tables created
- [ ] Start gateway: `cd gateway && bun run dev`
- [ ] Health check: `curl localhost:3001/health` → `{ "status": "ok" }`
- [ ] Test message: `curl -X POST localhost:3001/webhook/test -H 'Content-Type: application/json' -d '{"senderId":"dev1","text":"Hi"}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)