### PR TITLE
feat(gateway): define message types and ChatAdapter interface

### DIFF
--- a/gateway/src/types/adapter.ts
+++ b/gateway/src/types/adapter.ts
@@ -1,0 +1,9 @@
+import type { InboundMessage, OutboundMessage } from './messages'
+
+export interface ChatAdapter {
+	readonly provider: string
+	parseInbound(raw: unknown): Promise<InboundMessage>
+	sendReply(message: OutboundMessage): Promise<void>
+	resolveUser(senderId: string): Promise<{ userId: string }>
+	verifyWebhook(request: Request): Promise<boolean>
+}

--- a/gateway/src/types/index.ts
+++ b/gateway/src/types/index.ts
@@ -1,1 +1,7 @@
-// Gateway type definitions
+export {
+	InboundMessageSchema,
+	OutboundMessageSchema,
+	type InboundMessage,
+	type OutboundMessage,
+} from './messages'
+export type { ChatAdapter } from './adapter'

--- a/gateway/src/types/messages.ts
+++ b/gateway/src/types/messages.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod'
+
+export let InboundMessageSchema = z.object({
+	provider: z.string().min(1),
+	senderId: z.string().min(1),
+	userId: z.string().uuid(),
+	text: z.string().min(1),
+	threadId: z.string().min(1),
+	timestamp: z.number().int().positive(),
+})
+
+export type InboundMessage = z.infer<typeof InboundMessageSchema>
+
+export let OutboundMessageSchema = z.object({
+	provider: z.string().min(1),
+	senderId: z.string().min(1),
+	threadId: z.string().min(1),
+	text: z.string().min(1),
+})
+
+export type OutboundMessage = z.infer<typeof OutboundMessageSchema>

--- a/gateway/tests/types/messages.test.ts
+++ b/gateway/tests/types/messages.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect } from 'bun:test'
+import { InboundMessageSchema, OutboundMessageSchema } from '../../src/types/messages'
+
+describe('InboundMessageSchema', () => {
+	test('valid payload passes validation', () => {
+		let valid = {
+			provider: 'telegram',
+			senderId: '12345',
+			userId: '550e8400-e29b-41d4-a716-446655440000',
+			text: 'Hello matchmaker',
+			threadId: 'thread-abc',
+			timestamp: 1711900000000,
+		}
+
+		let result = InboundMessageSchema.safeParse(valid)
+
+		expect(result.success).toBe(true)
+		if (result.success) {
+			expect(result.data.provider).toBe('telegram')
+			expect(result.data.senderId).toBe('12345')
+			expect(result.data.text).toBe('Hello matchmaker')
+		}
+	})
+
+	test('missing text field fails validation', () => {
+		let invalid = {
+			provider: 'telegram',
+			senderId: '12345',
+			userId: '550e8400-e29b-41d4-a716-446655440000',
+			threadId: 'thread-abc',
+			timestamp: 1711900000000,
+		}
+
+		let result = InboundMessageSchema.safeParse(invalid)
+
+		expect(result.success).toBe(false)
+	})
+
+	test('empty senderId fails validation', () => {
+		let invalid = {
+			provider: 'telegram',
+			senderId: '',
+			userId: '550e8400-e29b-41d4-a716-446655440000',
+			text: 'Hello',
+			threadId: 'thread-abc',
+			timestamp: 1711900000000,
+		}
+
+		let result = InboundMessageSchema.safeParse(invalid)
+
+		expect(result.success).toBe(false)
+	})
+
+	test('invalid userId (not UUID) fails validation', () => {
+		let invalid = {
+			provider: 'telegram',
+			senderId: '12345',
+			userId: 'not-a-uuid',
+			text: 'Hello',
+			threadId: 'thread-abc',
+			timestamp: 1711900000000,
+		}
+
+		let result = InboundMessageSchema.safeParse(invalid)
+
+		expect(result.success).toBe(false)
+	})
+})
+
+describe('OutboundMessageSchema', () => {
+	test('valid payload passes validation', () => {
+		let valid = {
+			provider: 'telegram',
+			senderId: '12345',
+			threadId: 'thread-abc',
+			text: 'Here are your matches!',
+		}
+
+		let result = OutboundMessageSchema.safeParse(valid)
+
+		expect(result.success).toBe(true)
+		if (result.success) {
+			expect(result.data.text).toBe('Here are your matches!')
+		}
+	})
+
+	test('missing threadId fails validation', () => {
+		let invalid = {
+			provider: 'telegram',
+			senderId: '12345',
+			text: 'Hello',
+		}
+
+		let result = OutboundMessageSchema.safeParse(invalid)
+
+		expect(result.success).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary
- Zod v4 schemas for `InboundMessage` (provider, senderId, userId UUID, text, threadId, timestamp) and `OutboundMessage` (provider, senderId, threadId, text)
- `ChatAdapter` interface: `parseInbound`, `sendReply`, `resolveUser`, `verifyWebhook`
- 6 new schema validation tests (valid payloads, missing fields, empty strings, invalid UUID)

## Test plan
- [x] `cd gateway && bun test` — 8 tests pass (2 health + 6 schema)
- [ ] CI: test + coverage workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)