### PR TITLE
fix(ci): correct base coverage path for shared package

### DIFF
--- a/.github/workflows/coverage-diff.yml
+++ b/.github/workflows/coverage-diff.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Run tests with coverage (base - shared)
         run: |
           if [ -d __base/packages/shared ]; then
-            cd __base/packages/shared && bun test --coverage --coverage-reporter=lcov --coverage-dir=../../coverage/base/shared || true
+            cd __base/packages/shared && bun test --coverage --coverage-reporter=lcov --coverage-dir=../../../coverage/base/shared || true
           fi
 
       - name: Run tests with coverage (PR - gateway)


### PR DESCRIPTION
## Summary
- Fixed `coverage-diff.yml` base-side shared coverage path: `../../` → `../../../`
- From `__base/packages/shared`, 2 levels up only reaches `__base/` — needs 3 levels to reach the workspace root where the coverage script reads from
- This caused `shared` to always show as "New package" in coverage reports since the base lcov file was written to the wrong location

## Test plan
- [ ] CI: coverage-diff report should show shared with a normal diff table instead of "New package"

🤖 Generated with [Claude Code](https://claude.com/claude-code)