### PR TITLE
fix(mcp): expand preferences inputSchema with nested types and enums

### DIFF
--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -69,7 +69,60 @@ export function createServer(apiClient: ApiClient) {
 						age: { type: 'number', description: 'Person age' },
 						location: { type: 'string', description: 'Person location' },
 						gender: { type: 'string', description: 'Person gender' },
-						preferences: { type: 'object', description: 'Person preferences' },
+						preferences: {
+							type: 'object',
+							properties: {
+								aboutMe: {
+									type: 'object',
+									properties: {
+										height: { type: 'number', description: 'Height in cm' },
+										build: { type: 'string', enum: ['slim', 'average', 'athletic', 'heavy'] },
+										fitnessLevel: { type: 'string', enum: ['active', 'average', 'sedentary'] },
+										ethnicity: { type: 'string' },
+										religion: { type: 'string' },
+										hasChildren: { type: 'boolean' },
+										numberOfChildren: { type: 'number' },
+										isDivorced: { type: 'boolean' },
+										hasTattoos: { type: 'boolean' },
+										hasPiercings: { type: 'boolean' },
+										isSmoker: { type: 'boolean' },
+										occupation: { type: 'string' },
+										income: { type: 'string', enum: ['high', 'moderate', 'low'] },
+									},
+								},
+								lookingFor: {
+									type: 'object',
+									properties: {
+										ageRange: {
+											type: 'object',
+											properties: {
+												min: { type: 'number' },
+												max: { type: 'number' },
+											},
+										},
+										heightRange: {
+											type: 'object',
+											properties: {
+												min: { type: 'number' },
+												max: { type: 'number' },
+											},
+										},
+										fitnessPreference: { type: 'string', enum: ['active', 'average', 'any'] },
+										ethnicityPreference: { type: 'array', items: { type: 'string' } },
+										incomePreference: { type: 'string', enum: ['high', 'moderate', 'any'] },
+										religionRequired: { type: 'string' },
+										wantsChildren: { type: 'boolean' },
+									},
+								},
+								dealBreakers: {
+									type: 'array',
+									items: {
+										type: 'string',
+										enum: ['isDivorced', 'hasChildren', 'hasTattoos', 'hasPiercings', 'isSmoker'],
+									},
+								},
+							},
+						},
 						personality: { type: 'object', description: 'Person personality traits' },
 						notes: { type: 'string', description: 'Notes about the person' },
 					},


### PR DESCRIPTION
Replace the opaque `{ type: 'object' }` preferences property with a fully-specified JSON Schema matching the Zod definitions in backend/src/schemas/preferences.ts — including enums for build, fitnessLevel, income, fitnessPreference, incomePreference, and dealBreakers, and structured objects for ageRange and heightRange.

The LLM now gets machine-readable structure instead of guessing the shape from a prose description.

Closes Issue: #26 