### PR TITLE
feat(shared): define domain entities for Clean Architecture (#51)

### DIFF
--- a/packages/shared/src/domain/errors.ts
+++ b/packages/shared/src/domain/errors.ts
@@ -1,0 +1,10 @@
+export class DomainError extends Error {
+	readonly code: string
+
+	constructor(code: string, message: string) {
+		super(message)
+		this.name = 'DomainError'
+		this.code = code
+		Object.setPrototypeOf(this, new.target.prototype)
+	}
+}

--- a/packages/shared/src/domain/index.ts
+++ b/packages/shared/src/domain/index.ts
@@ -1,0 +1,5 @@
+export * from './errors.js'
+export * from './preferences.js'
+export * from './person.js'
+export * from './introduction.js'
+export * from './match-decision.js'

--- a/packages/shared/src/domain/introduction.ts
+++ b/packages/shared/src/domain/introduction.ts
@@ -1,11 +1,6 @@
-/**
- * Introduction domain entity.
- *
- * Links two people across (possibly distinct) matchmakers and tracks the
- * lifecycle status of the match. Framework-free; the adapter layer maps
- * DB rows and Zod shapes into this type.
- */
+/** Introduction domain entity — links two people across matchmakers and tracks match lifecycle. */
 import { DomainError } from './errors.js'
+import { requireNonEmptyString, assertValidDate } from './validators.js'
 
 export class InvalidIntroductionError extends DomainError {
 	constructor(code: string, message: string) {
@@ -48,78 +43,85 @@ const STATUSES: readonly IntroductionStatus[] = [
 	'ended',
 ]
 
-function invalid(code: string, message: string): never {
-	throw new InvalidIntroductionError(code, message)
-}
-
-function requireNonEmptyString(value: string, field: string, code: string): void {
-	if (typeof value !== 'string' || value.trim().length === 0) {
-		invalid(code, `${field} must be a non-empty string`)
-	}
-}
-
-function validateDate(value: Date, field: string, code: string): Date {
-	if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-		invalid(code, `${field} must be a valid Date`)
-	}
-	return value
-}
-
 export function createIntroduction(input: IntroductionInput): Introduction {
-	requireNonEmptyString(input.id, 'id', 'INVALID_INTRODUCTION_ID')
-	requireNonEmptyString(
+	const id = requireNonEmptyString(
+		input.id,
+		'id',
+		'INVALID_INTRODUCTION_ID',
+		InvalidIntroductionError,
+	)
+	// matchmakerAId === matchmakerBId is intentionally allowed: a single matchmaker may
+	// introduce two of their own people without involving a second matchmaker.
+	const matchmakerAId = requireNonEmptyString(
 		input.matchmakerAId,
 		'matchmakerAId',
 		'INVALID_INTRODUCTION_MATCHMAKER_A_ID',
+		InvalidIntroductionError,
 	)
-	requireNonEmptyString(
+	const matchmakerBId = requireNonEmptyString(
 		input.matchmakerBId,
 		'matchmakerBId',
 		'INVALID_INTRODUCTION_MATCHMAKER_B_ID',
+		InvalidIntroductionError,
 	)
-	requireNonEmptyString(input.personAId, 'personAId', 'INVALID_INTRODUCTION_PERSON_A_ID')
-	requireNonEmptyString(input.personBId, 'personBId', 'INVALID_INTRODUCTION_PERSON_B_ID')
+	const personAId = requireNonEmptyString(
+		input.personAId,
+		'personAId',
+		'INVALID_INTRODUCTION_PERSON_A_ID',
+		InvalidIntroductionError,
+	)
+	const personBId = requireNonEmptyString(
+		input.personBId,
+		'personBId',
+		'INVALID_INTRODUCTION_PERSON_B_ID',
+		InvalidIntroductionError,
+	)
 
-	if (input.personAId === input.personBId) {
-		invalid(
+	if (personAId === personBId) {
+		throw new InvalidIntroductionError(
 			'INVALID_INTRODUCTION_SELF',
 			'personAId and personBId must refer to different people',
 		)
 	}
 
-	let status: IntroductionStatus = input.status ?? 'pending'
+	const status: IntroductionStatus = input.status ?? 'pending'
 	if (!STATUSES.includes(status)) {
-		invalid(
+		throw new InvalidIntroductionError(
 			'INVALID_INTRODUCTION_STATUS',
 			`status must be one of ${STATUSES.join(', ')}`,
 		)
 	}
 
-	let createdAt = validateDate(
+	assertValidDate(
 		input.createdAt,
 		'createdAt',
 		'INVALID_INTRODUCTION_CREATED_AT',
+		InvalidIntroductionError,
 	)
-	let updatedAt = validateDate(
+	assertValidDate(
 		input.updatedAt,
 		'updatedAt',
 		'INVALID_INTRODUCTION_UPDATED_AT',
+		InvalidIntroductionError,
 	)
 
-	if (updatedAt.getTime() < createdAt.getTime()) {
-		invalid('INVALID_INTRODUCTION_TIMESTAMPS', 'updatedAt must be >= createdAt')
+	if (input.updatedAt.getTime() < input.createdAt.getTime()) {
+		throw new InvalidIntroductionError(
+			'INVALID_INTRODUCTION_TIMESTAMPS',
+			'updatedAt must be >= createdAt',
+		)
 	}
 
-	let introduction: Introduction = {
-		id: input.id,
-		matchmakerAId: input.matchmakerAId,
-		matchmakerBId: input.matchmakerBId,
-		personAId: input.personAId,
-		personBId: input.personBId,
+	const introduction: Introduction = {
+		id,
+		matchmakerAId,
+		matchmakerBId,
+		personAId,
+		personBId,
 		status,
 		notes: input.notes ?? null,
-		createdAt,
-		updatedAt,
+		createdAt: input.createdAt,
+		updatedAt: input.updatedAt,
 	}
 
 	return Object.freeze(introduction)

--- a/packages/shared/src/domain/introduction.ts
+++ b/packages/shared/src/domain/introduction.ts
@@ -35,7 +35,7 @@ export interface IntroductionInput {
 	readonly updatedAt: Date
 }
 
-const STATUSES: readonly IntroductionStatus[] = [
+let STATUSES: readonly IntroductionStatus[] = [
 	'pending',
 	'accepted',
 	'declined',
@@ -44,7 +44,7 @@ const STATUSES: readonly IntroductionStatus[] = [
 ]
 
 export function createIntroduction(input: IntroductionInput): Introduction {
-	const id = requireNonEmptyString(
+	let id = requireNonEmptyString(
 		input.id,
 		'id',
 		'INVALID_INTRODUCTION_ID',
@@ -52,25 +52,25 @@ export function createIntroduction(input: IntroductionInput): Introduction {
 	)
 	// matchmakerAId === matchmakerBId is intentionally allowed: a single matchmaker may
 	// introduce two of their own people without involving a second matchmaker.
-	const matchmakerAId = requireNonEmptyString(
+	let matchmakerAId = requireNonEmptyString(
 		input.matchmakerAId,
 		'matchmakerAId',
 		'INVALID_INTRODUCTION_MATCHMAKER_A_ID',
 		InvalidIntroductionError,
 	)
-	const matchmakerBId = requireNonEmptyString(
+	let matchmakerBId = requireNonEmptyString(
 		input.matchmakerBId,
 		'matchmakerBId',
 		'INVALID_INTRODUCTION_MATCHMAKER_B_ID',
 		InvalidIntroductionError,
 	)
-	const personAId = requireNonEmptyString(
+	let personAId = requireNonEmptyString(
 		input.personAId,
 		'personAId',
 		'INVALID_INTRODUCTION_PERSON_A_ID',
 		InvalidIntroductionError,
 	)
-	const personBId = requireNonEmptyString(
+	let personBId = requireNonEmptyString(
 		input.personBId,
 		'personBId',
 		'INVALID_INTRODUCTION_PERSON_B_ID',
@@ -84,7 +84,7 @@ export function createIntroduction(input: IntroductionInput): Introduction {
 		)
 	}
 
-	const status: IntroductionStatus = input.status ?? 'pending'
+	let status: IntroductionStatus = input.status ?? 'pending'
 	if (!STATUSES.includes(status)) {
 		throw new InvalidIntroductionError(
 			'INVALID_INTRODUCTION_STATUS',
@@ -112,7 +112,7 @@ export function createIntroduction(input: IntroductionInput): Introduction {
 		)
 	}
 
-	const introduction: Introduction = {
+	let introduction: Introduction = {
 		id,
 		matchmakerAId,
 		matchmakerBId,

--- a/packages/shared/src/domain/introduction.ts
+++ b/packages/shared/src/domain/introduction.ts
@@ -40,6 +40,87 @@ export interface IntroductionInput {
 	readonly updatedAt: Date
 }
 
-export function createIntroduction(_input: IntroductionInput): Introduction {
-	throw new Error('Not implemented')
+const STATUSES: readonly IntroductionStatus[] = [
+	'pending',
+	'accepted',
+	'declined',
+	'dating',
+	'ended',
+]
+
+function invalid(code: string, message: string): never {
+	throw new InvalidIntroductionError(code, message)
+}
+
+function requireNonEmptyString(value: string, field: string, code: string): void {
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		invalid(code, `${field} must be a non-empty string`)
+	}
+}
+
+function validateDate(value: Date, field: string, code: string): Date {
+	if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+		invalid(code, `${field} must be a valid Date`)
+	}
+	return value
+}
+
+export function createIntroduction(input: IntroductionInput): Introduction {
+	requireNonEmptyString(input.id, 'id', 'INVALID_INTRODUCTION_ID')
+	requireNonEmptyString(
+		input.matchmakerAId,
+		'matchmakerAId',
+		'INVALID_INTRODUCTION_MATCHMAKER_A_ID',
+	)
+	requireNonEmptyString(
+		input.matchmakerBId,
+		'matchmakerBId',
+		'INVALID_INTRODUCTION_MATCHMAKER_B_ID',
+	)
+	requireNonEmptyString(input.personAId, 'personAId', 'INVALID_INTRODUCTION_PERSON_A_ID')
+	requireNonEmptyString(input.personBId, 'personBId', 'INVALID_INTRODUCTION_PERSON_B_ID')
+
+	if (input.personAId === input.personBId) {
+		invalid(
+			'INVALID_INTRODUCTION_SELF',
+			'personAId and personBId must refer to different people',
+		)
+	}
+
+	let status: IntroductionStatus = input.status ?? 'pending'
+	if (!STATUSES.includes(status)) {
+		invalid(
+			'INVALID_INTRODUCTION_STATUS',
+			`status must be one of ${STATUSES.join(', ')}`,
+		)
+	}
+
+	let createdAt = validateDate(
+		input.createdAt,
+		'createdAt',
+		'INVALID_INTRODUCTION_CREATED_AT',
+	)
+	let updatedAt = validateDate(
+		input.updatedAt,
+		'updatedAt',
+		'INVALID_INTRODUCTION_UPDATED_AT',
+	)
+
+	if (updatedAt.getTime() < createdAt.getTime()) {
+		invalid('INVALID_INTRODUCTION_TIMESTAMPS', 'updatedAt must be >= createdAt')
+	}
+
+	let introduction: Introduction = {
+		id: input.id,
+		matchmakerAId: input.matchmakerAId,
+		matchmakerBId: input.matchmakerBId,
+		personAId: input.personAId,
+		personBId: input.personBId,
+		status,
+		notes: input.notes ?? null,
+		createdAt,
+		updatedAt,
+	}
+
+	return Object.freeze(introduction)
 }

--- a/packages/shared/src/domain/introduction.ts
+++ b/packages/shared/src/domain/introduction.ts
@@ -1,0 +1,45 @@
+/**
+ * Introduction domain entity.
+ *
+ * Links two people across (possibly distinct) matchmakers and tracks the
+ * lifecycle status of the match. Framework-free; the adapter layer maps
+ * DB rows and Zod shapes into this type.
+ */
+import { DomainError } from './errors.js'
+
+export class InvalidIntroductionError extends DomainError {
+	constructor(code: string, message: string) {
+		super(code, message)
+		this.name = 'InvalidIntroductionError'
+	}
+}
+
+export type IntroductionStatus = 'pending' | 'accepted' | 'declined' | 'dating' | 'ended'
+
+export interface Introduction {
+	readonly id: string
+	readonly matchmakerAId: string
+	readonly matchmakerBId: string
+	readonly personAId: string
+	readonly personBId: string
+	readonly status: IntroductionStatus
+	readonly notes: string | null
+	readonly createdAt: Date
+	readonly updatedAt: Date
+}
+
+export interface IntroductionInput {
+	readonly id: string
+	readonly matchmakerAId: string
+	readonly matchmakerBId: string
+	readonly personAId: string
+	readonly personBId: string
+	readonly status?: IntroductionStatus
+	readonly notes?: string | null
+	readonly createdAt: Date
+	readonly updatedAt: Date
+}
+
+export function createIntroduction(_input: IntroductionInput): Introduction {
+	throw new Error('Not implemented')
+}

--- a/packages/shared/src/domain/match-decision.ts
+++ b/packages/shared/src/domain/match-decision.ts
@@ -73,25 +73,22 @@ export function createMatchDecision(input: MatchDecisionInput): MatchDecision {
 		)
 	}
 
-	let declineReason: string | null = null
+	// Empty/whitespace declineReason normalizes to null on both branches.
+	// Adapters often coerce missing form fields to '' — treat that as "absent"
+	// rather than a validation error. A meaningful (non-empty) reason on an
+	// accepted decision is still a caller bug and throws.
 	const rawReason = input.declineReason
+	const trimmedReason =
+		typeof rawReason === 'string' && rawReason.trim().length > 0 ? rawReason.trim() : null
 
-	if (input.decision === 'accepted') {
-		if (rawReason !== undefined && rawReason !== null) {
-			throw new InvalidMatchDecisionError(
-				'INVALID_MATCH_DECISION_ACCEPTED_REASON',
-				'declineReason must be null when decision is accepted',
-			)
-		}
-	} else if (rawReason !== undefined && rawReason !== null) {
-		if (typeof rawReason !== 'string' || rawReason.trim().length === 0) {
-			throw new InvalidMatchDecisionError(
-				'INVALID_MATCH_DECISION_DECLINE_REASON',
-				'declineReason must be a non-empty string when provided',
-			)
-		}
-		declineReason = rawReason
+	if (input.decision === 'accepted' && trimmedReason !== null) {
+		throw new InvalidMatchDecisionError(
+			'INVALID_MATCH_DECISION_ACCEPTED_REASON',
+			'declineReason must be null when decision is accepted',
+		)
 	}
+
+	const declineReason = input.decision === 'declined' ? trimmedReason : null
 
 	assertValidDate(
 		input.createdAt,

--- a/packages/shared/src/domain/match-decision.ts
+++ b/packages/shared/src/domain/match-decision.ts
@@ -36,6 +36,88 @@ export interface MatchDecisionInput {
 	readonly createdAt: Date
 }
 
-export function createMatchDecision(_input: MatchDecisionInput): MatchDecision {
-	throw new Error('Not implemented')
+const DECISIONS: readonly Decision[] = ['accepted', 'declined']
+
+function invalid(code: string, message: string): never {
+	throw new InvalidMatchDecisionError(code, message)
+}
+
+function requireNonEmptyString(value: string, field: string, code: string): void {
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		invalid(code, `${field} must be a non-empty string`)
+	}
+}
+
+function validateDate(value: Date, field: string, code: string): Date {
+	if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+		invalid(code, `${field} must be a valid Date`)
+	}
+	return value
+}
+
+export function createMatchDecision(input: MatchDecisionInput): MatchDecision {
+	requireNonEmptyString(input.id, 'id', 'INVALID_MATCH_DECISION_ID')
+	requireNonEmptyString(
+		input.matchmakerId,
+		'matchmakerId',
+		'INVALID_MATCH_DECISION_MATCHMAKER_ID',
+	)
+	requireNonEmptyString(input.personId, 'personId', 'INVALID_MATCH_DECISION_PERSON_ID')
+	requireNonEmptyString(
+		input.candidateId,
+		'candidateId',
+		'INVALID_MATCH_DECISION_CANDIDATE_ID',
+	)
+
+	if (input.personId === input.candidateId) {
+		invalid(
+			'INVALID_MATCH_DECISION_SELF',
+			'personId and candidateId must refer to different people',
+		)
+	}
+
+	if (!DECISIONS.includes(input.decision)) {
+		invalid(
+			'INVALID_MATCH_DECISION_DECISION',
+			`decision must be one of ${DECISIONS.join(', ')}`,
+		)
+	}
+
+	let declineReason: string | null = null
+	let rawReason = input.declineReason
+
+	if (input.decision === 'accepted') {
+		if (rawReason !== undefined && rawReason !== null) {
+			invalid(
+				'INVALID_MATCH_DECISION_ACCEPTED_REASON',
+				'declineReason must be null when decision is accepted',
+			)
+		}
+	} else if (rawReason !== undefined && rawReason !== null) {
+		if (typeof rawReason !== 'string' || rawReason.trim().length === 0) {
+			invalid(
+				'INVALID_MATCH_DECISION_DECLINE_REASON',
+				'declineReason must be a non-empty string when provided',
+			)
+		}
+		declineReason = rawReason
+	}
+
+	let createdAt = validateDate(
+		input.createdAt,
+		'createdAt',
+		'INVALID_MATCH_DECISION_CREATED_AT',
+	)
+
+	let decision: MatchDecision = {
+		id: input.id,
+		matchmakerId: input.matchmakerId,
+		personId: input.personId,
+		candidateId: input.candidateId,
+		decision: input.decision,
+		declineReason,
+		createdAt,
+	}
+
+	return Object.freeze(decision)
 }

--- a/packages/shared/src/domain/match-decision.ts
+++ b/packages/shared/src/domain/match-decision.ts
@@ -31,28 +31,28 @@ export interface MatchDecisionInput {
 	readonly createdAt: Date
 }
 
-const DECISIONS: readonly Decision[] = ['accepted', 'declined']
+let DECISIONS: readonly Decision[] = ['accepted', 'declined']
 
 export function createMatchDecision(input: MatchDecisionInput): MatchDecision {
-	const id = requireNonEmptyString(
+	let id = requireNonEmptyString(
 		input.id,
 		'id',
 		'INVALID_MATCH_DECISION_ID',
 		InvalidMatchDecisionError,
 	)
-	const matchmakerId = requireNonEmptyString(
+	let matchmakerId = requireNonEmptyString(
 		input.matchmakerId,
 		'matchmakerId',
 		'INVALID_MATCH_DECISION_MATCHMAKER_ID',
 		InvalidMatchDecisionError,
 	)
-	const personId = requireNonEmptyString(
+	let personId = requireNonEmptyString(
 		input.personId,
 		'personId',
 		'INVALID_MATCH_DECISION_PERSON_ID',
 		InvalidMatchDecisionError,
 	)
-	const candidateId = requireNonEmptyString(
+	let candidateId = requireNonEmptyString(
 		input.candidateId,
 		'candidateId',
 		'INVALID_MATCH_DECISION_CANDIDATE_ID',
@@ -77,8 +77,8 @@ export function createMatchDecision(input: MatchDecisionInput): MatchDecision {
 	// Adapters often coerce missing form fields to '' — treat that as "absent"
 	// rather than a validation error. A meaningful (non-empty) reason on an
 	// accepted decision is still a caller bug and throws.
-	const rawReason = input.declineReason
-	const trimmedReason =
+	let rawReason = input.declineReason
+	let trimmedReason =
 		typeof rawReason === 'string' && rawReason.trim().length > 0 ? rawReason.trim() : null
 
 	if (input.decision === 'accepted' && trimmedReason !== null) {
@@ -88,7 +88,7 @@ export function createMatchDecision(input: MatchDecisionInput): MatchDecision {
 		)
 	}
 
-	const declineReason = input.decision === 'declined' ? trimmedReason : null
+	let declineReason = input.decision === 'declined' ? trimmedReason : null
 
 	assertValidDate(
 		input.createdAt,
@@ -97,7 +97,7 @@ export function createMatchDecision(input: MatchDecisionInput): MatchDecision {
 		InvalidMatchDecisionError,
 	)
 
-	const decision: MatchDecision = {
+	let decision: MatchDecision = {
 		id,
 		matchmakerId,
 		personId,

--- a/packages/shared/src/domain/match-decision.ts
+++ b/packages/shared/src/domain/match-decision.ts
@@ -1,0 +1,41 @@
+/**
+ * MatchDecision domain entity.
+ *
+ * Records a matchmaker's accept/decline decision for a candidate in
+ * relation to a primary person. Has one cross-field rule: declineReason
+ * is only meaningful when decision === 'declined'.
+ */
+import { DomainError } from './errors.js'
+
+export class InvalidMatchDecisionError extends DomainError {
+	constructor(code: string, message: string) {
+		super(code, message)
+		this.name = 'InvalidMatchDecisionError'
+	}
+}
+
+export type Decision = 'accepted' | 'declined'
+
+export interface MatchDecision {
+	readonly id: string
+	readonly matchmakerId: string
+	readonly personId: string
+	readonly candidateId: string
+	readonly decision: Decision
+	readonly declineReason: string | null
+	readonly createdAt: Date
+}
+
+export interface MatchDecisionInput {
+	readonly id: string
+	readonly matchmakerId: string
+	readonly personId: string
+	readonly candidateId: string
+	readonly decision: Decision
+	readonly declineReason?: string | null
+	readonly createdAt: Date
+}
+
+export function createMatchDecision(_input: MatchDecisionInput): MatchDecision {
+	throw new Error('Not implemented')
+}

--- a/packages/shared/src/domain/match-decision.ts
+++ b/packages/shared/src/domain/match-decision.ts
@@ -1,11 +1,6 @@
-/**
- * MatchDecision domain entity.
- *
- * Records a matchmaker's accept/decline decision for a candidate in
- * relation to a primary person. Has one cross-field rule: declineReason
- * is only meaningful when decision === 'declined'.
- */
+/** MatchDecision domain entity — records a matchmaker's accept/decline decision for a candidate. */
 import { DomainError } from './errors.js'
+import { requireNonEmptyString, assertValidDate } from './validators.js'
 
 export class InvalidMatchDecisionError extends DomainError {
 	constructor(code: string, message: string) {
@@ -38,64 +33,59 @@ export interface MatchDecisionInput {
 
 const DECISIONS: readonly Decision[] = ['accepted', 'declined']
 
-function invalid(code: string, message: string): never {
-	throw new InvalidMatchDecisionError(code, message)
-}
-
-function requireNonEmptyString(value: string, field: string, code: string): void {
-	if (typeof value !== 'string' || value.trim().length === 0) {
-		invalid(code, `${field} must be a non-empty string`)
-	}
-}
-
-function validateDate(value: Date, field: string, code: string): Date {
-	if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-		invalid(code, `${field} must be a valid Date`)
-	}
-	return value
-}
-
 export function createMatchDecision(input: MatchDecisionInput): MatchDecision {
-	requireNonEmptyString(input.id, 'id', 'INVALID_MATCH_DECISION_ID')
-	requireNonEmptyString(
+	const id = requireNonEmptyString(
+		input.id,
+		'id',
+		'INVALID_MATCH_DECISION_ID',
+		InvalidMatchDecisionError,
+	)
+	const matchmakerId = requireNonEmptyString(
 		input.matchmakerId,
 		'matchmakerId',
 		'INVALID_MATCH_DECISION_MATCHMAKER_ID',
+		InvalidMatchDecisionError,
 	)
-	requireNonEmptyString(input.personId, 'personId', 'INVALID_MATCH_DECISION_PERSON_ID')
-	requireNonEmptyString(
+	const personId = requireNonEmptyString(
+		input.personId,
+		'personId',
+		'INVALID_MATCH_DECISION_PERSON_ID',
+		InvalidMatchDecisionError,
+	)
+	const candidateId = requireNonEmptyString(
 		input.candidateId,
 		'candidateId',
 		'INVALID_MATCH_DECISION_CANDIDATE_ID',
+		InvalidMatchDecisionError,
 	)
 
-	if (input.personId === input.candidateId) {
-		invalid(
+	if (personId === candidateId) {
+		throw new InvalidMatchDecisionError(
 			'INVALID_MATCH_DECISION_SELF',
 			'personId and candidateId must refer to different people',
 		)
 	}
 
 	if (!DECISIONS.includes(input.decision)) {
-		invalid(
+		throw new InvalidMatchDecisionError(
 			'INVALID_MATCH_DECISION_DECISION',
 			`decision must be one of ${DECISIONS.join(', ')}`,
 		)
 	}
 
 	let declineReason: string | null = null
-	let rawReason = input.declineReason
+	const rawReason = input.declineReason
 
 	if (input.decision === 'accepted') {
 		if (rawReason !== undefined && rawReason !== null) {
-			invalid(
+			throw new InvalidMatchDecisionError(
 				'INVALID_MATCH_DECISION_ACCEPTED_REASON',
 				'declineReason must be null when decision is accepted',
 			)
 		}
 	} else if (rawReason !== undefined && rawReason !== null) {
 		if (typeof rawReason !== 'string' || rawReason.trim().length === 0) {
-			invalid(
+			throw new InvalidMatchDecisionError(
 				'INVALID_MATCH_DECISION_DECLINE_REASON',
 				'declineReason must be a non-empty string when provided',
 			)
@@ -103,20 +93,21 @@ export function createMatchDecision(input: MatchDecisionInput): MatchDecision {
 		declineReason = rawReason
 	}
 
-	let createdAt = validateDate(
+	assertValidDate(
 		input.createdAt,
 		'createdAt',
 		'INVALID_MATCH_DECISION_CREATED_AT',
+		InvalidMatchDecisionError,
 	)
 
-	let decision: MatchDecision = {
-		id: input.id,
-		matchmakerId: input.matchmakerId,
-		personId: input.personId,
-		candidateId: input.candidateId,
+	const decision: MatchDecision = {
+		id,
+		matchmakerId,
+		personId,
+		candidateId,
 		decision: input.decision,
 		declineReason,
-		createdAt,
+		createdAt: input.createdAt,
 	}
 
 	return Object.freeze(decision)

--- a/packages/shared/src/domain/person.ts
+++ b/packages/shared/src/domain/person.ts
@@ -1,16 +1,6 @@
-/**
- * Person domain entity.
- *
- * Framework-free representation of a person tracked by a matchmaker.
- * Snake_case DB columns map to camelCase here; ISO timestamp strings
- * map to `Date`. Adapter layer owns the mapping — this module speaks
- * only in domain types.
- *
- * `preferences` stays typed as `Record<string, unknown> | null` in this
- * issue. A later issue in the Clean Architecture epic will tighten it
- * to the `Preferences` value object once existing rows are audited.
- */
+/** Person domain entity — framework-free representation of a person tracked by a matchmaker. */
 import { DomainError } from './errors.js'
+import { requireNonEmptyString, assertValidDate } from './validators.js'
 
 export class InvalidPersonError extends DomainError {
 	constructor(code: string, message: string) {
@@ -49,24 +39,6 @@ export interface PersonInput {
 	readonly updatedAt: Date
 }
 
-function invalid(code: string, message: string): never {
-	throw new InvalidPersonError(code, message)
-}
-
-function requireNonEmptyString(value: string, field: string, code: string): string {
-	if (typeof value !== 'string' || value.trim().length === 0) {
-		invalid(code, `${field} must be a non-empty string`)
-	}
-	return value
-}
-
-function validateDate(value: Date, field: string, code: string): Date {
-	if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
-		invalid(code, `${field} must be a valid Date`)
-	}
-	return value
-}
-
 function freezeRecord(
 	value: Record<string, unknown> | null | undefined,
 ): Readonly<Record<string, unknown>> | null {
@@ -75,8 +47,8 @@ function freezeRecord(
 }
 
 export function createPerson(input: PersonInput): Person {
-	requireNonEmptyString(input.id, 'id', 'INVALID_PERSON_ID')
-	requireNonEmptyString(input.name, 'name', 'INVALID_PERSON_NAME')
+	const id = requireNonEmptyString(input.id, 'id', 'INVALID_PERSON_ID', InvalidPersonError)
+	const name = requireNonEmptyString(input.name, 'name', 'INVALID_PERSON_NAME', InvalidPersonError)
 
 	let age: number | null = null
 	if (input.age !== undefined && input.age !== null) {
@@ -86,32 +58,35 @@ export function createPerson(input: PersonInput): Person {
 			!Number.isInteger(input.age) ||
 			input.age < 18
 		) {
-			invalid('INVALID_PERSON_AGE', 'age must be an integer >= 18 when provided')
+			throw new InvalidPersonError(
+				'INVALID_PERSON_AGE',
+				'age must be an integer >= 18 when provided',
+			)
 		}
 		age = input.age
 	}
 
 	let matchmakerId: string | null = null
 	if (input.matchmakerId !== undefined && input.matchmakerId !== null) {
-		requireNonEmptyString(
+		matchmakerId = requireNonEmptyString(
 			input.matchmakerId,
 			'matchmakerId',
 			'INVALID_PERSON_MATCHMAKER_ID',
+			InvalidPersonError,
 		)
-		matchmakerId = input.matchmakerId
 	}
 
-	let createdAt = validateDate(input.createdAt, 'createdAt', 'INVALID_PERSON_CREATED_AT')
-	let updatedAt = validateDate(input.updatedAt, 'updatedAt', 'INVALID_PERSON_UPDATED_AT')
+	assertValidDate(input.createdAt, 'createdAt', 'INVALID_PERSON_CREATED_AT', InvalidPersonError)
+	assertValidDate(input.updatedAt, 'updatedAt', 'INVALID_PERSON_UPDATED_AT', InvalidPersonError)
 
-	if (updatedAt.getTime() < createdAt.getTime()) {
-		invalid('INVALID_PERSON_TIMESTAMPS', 'updatedAt must be >= createdAt')
+	if (input.updatedAt.getTime() < input.createdAt.getTime()) {
+		throw new InvalidPersonError('INVALID_PERSON_TIMESTAMPS', 'updatedAt must be >= createdAt')
 	}
 
-	let person: Person = {
-		id: input.id,
+	const person: Person = {
+		id,
 		matchmakerId,
-		name: input.name,
+		name,
 		age,
 		location: input.location ?? null,
 		gender: input.gender ?? null,
@@ -119,8 +94,8 @@ export function createPerson(input: PersonInput): Person {
 		personality: freezeRecord(input.personality),
 		notes: input.notes ?? null,
 		active: input.active ?? true,
-		createdAt,
-		updatedAt,
+		createdAt: input.createdAt,
+		updatedAt: input.updatedAt,
 	}
 
 	return Object.freeze(person)

--- a/packages/shared/src/domain/person.ts
+++ b/packages/shared/src/domain/person.ts
@@ -49,6 +49,79 @@ export interface PersonInput {
 	readonly updatedAt: Date
 }
 
-export function createPerson(_input: PersonInput): Person {
-	throw new Error('Not implemented')
+function invalid(code: string, message: string): never {
+	throw new InvalidPersonError(code, message)
+}
+
+function requireNonEmptyString(value: string, field: string, code: string): string {
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		invalid(code, `${field} must be a non-empty string`)
+	}
+	return value
+}
+
+function validateDate(value: Date, field: string, code: string): Date {
+	if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+		invalid(code, `${field} must be a valid Date`)
+	}
+	return value
+}
+
+function freezeRecord(
+	value: Record<string, unknown> | null | undefined,
+): Readonly<Record<string, unknown>> | null {
+	if (value === undefined || value === null) return null
+	return Object.freeze({ ...value })
+}
+
+export function createPerson(input: PersonInput): Person {
+	requireNonEmptyString(input.id, 'id', 'INVALID_PERSON_ID')
+	requireNonEmptyString(input.name, 'name', 'INVALID_PERSON_NAME')
+
+	let age: number | null = null
+	if (input.age !== undefined && input.age !== null) {
+		if (
+			typeof input.age !== 'number' ||
+			!Number.isFinite(input.age) ||
+			!Number.isInteger(input.age) ||
+			input.age < 18
+		) {
+			invalid('INVALID_PERSON_AGE', 'age must be an integer >= 18 when provided')
+		}
+		age = input.age
+	}
+
+	let matchmakerId: string | null = null
+	if (input.matchmakerId !== undefined && input.matchmakerId !== null) {
+		requireNonEmptyString(
+			input.matchmakerId,
+			'matchmakerId',
+			'INVALID_PERSON_MATCHMAKER_ID',
+		)
+		matchmakerId = input.matchmakerId
+	}
+
+	let createdAt = validateDate(input.createdAt, 'createdAt', 'INVALID_PERSON_CREATED_AT')
+	let updatedAt = validateDate(input.updatedAt, 'updatedAt', 'INVALID_PERSON_UPDATED_AT')
+
+	if (updatedAt.getTime() < createdAt.getTime()) {
+		invalid('INVALID_PERSON_TIMESTAMPS', 'updatedAt must be >= createdAt')
+	}
+
+	let person: Person = {
+		id: input.id,
+		matchmakerId,
+		name: input.name,
+		age,
+		location: input.location ?? null,
+		gender: input.gender ?? null,
+		preferences: freezeRecord(input.preferences),
+		personality: freezeRecord(input.personality),
+		notes: input.notes ?? null,
+		active: input.active ?? true,
+		createdAt,
+		updatedAt,
+	}
+
+	return Object.freeze(person)
 }

--- a/packages/shared/src/domain/person.ts
+++ b/packages/shared/src/domain/person.ts
@@ -47,8 +47,8 @@ function freezeRecord(
 }
 
 export function createPerson(input: PersonInput): Person {
-	const id = requireNonEmptyString(input.id, 'id', 'INVALID_PERSON_ID', InvalidPersonError)
-	const name = requireNonEmptyString(input.name, 'name', 'INVALID_PERSON_NAME', InvalidPersonError)
+	let id = requireNonEmptyString(input.id, 'id', 'INVALID_PERSON_ID', InvalidPersonError)
+	let name = requireNonEmptyString(input.name, 'name', 'INVALID_PERSON_NAME', InvalidPersonError)
 
 	let age: number | null = null
 	if (input.age !== undefined && input.age !== null) {
@@ -83,7 +83,7 @@ export function createPerson(input: PersonInput): Person {
 		throw new InvalidPersonError('INVALID_PERSON_TIMESTAMPS', 'updatedAt must be >= createdAt')
 	}
 
-	const person: Person = {
+	let person: Person = {
 		id,
 		matchmakerId,
 		name,

--- a/packages/shared/src/domain/person.ts
+++ b/packages/shared/src/domain/person.ts
@@ -1,0 +1,54 @@
+/**
+ * Person domain entity.
+ *
+ * Framework-free representation of a person tracked by a matchmaker.
+ * Snake_case DB columns map to camelCase here; ISO timestamp strings
+ * map to `Date`. Adapter layer owns the mapping — this module speaks
+ * only in domain types.
+ *
+ * `preferences` stays typed as `Record<string, unknown> | null` in this
+ * issue. A later issue in the Clean Architecture epic will tighten it
+ * to the `Preferences` value object once existing rows are audited.
+ */
+import { DomainError } from './errors.js'
+
+export class InvalidPersonError extends DomainError {
+	constructor(code: string, message: string) {
+		super(code, message)
+		this.name = 'InvalidPersonError'
+	}
+}
+
+export interface Person {
+	readonly id: string
+	readonly matchmakerId: string | null
+	readonly name: string
+	readonly age: number | null
+	readonly location: string | null
+	readonly gender: string | null
+	readonly preferences: Readonly<Record<string, unknown>> | null
+	readonly personality: Readonly<Record<string, unknown>> | null
+	readonly notes: string | null
+	readonly active: boolean
+	readonly createdAt: Date
+	readonly updatedAt: Date
+}
+
+export interface PersonInput {
+	readonly id: string
+	readonly matchmakerId?: string | null
+	readonly name: string
+	readonly age?: number | null
+	readonly location?: string | null
+	readonly gender?: string | null
+	readonly preferences?: Record<string, unknown> | null
+	readonly personality?: Record<string, unknown> | null
+	readonly notes?: string | null
+	readonly active?: boolean
+	readonly createdAt: Date
+	readonly updatedAt: Date
+}
+
+export function createPerson(_input: PersonInput): Person {
+	throw new Error('Not implemented')
+}

--- a/packages/shared/src/domain/preferences.ts
+++ b/packages/shared/src/domain/preferences.ts
@@ -1,14 +1,4 @@
-/**
- * Preferences value object for the domain layer.
- *
- * Framework-free representation of a person's self-description (aboutMe),
- * candidate preferences (lookingFor), and deal breakers. Part of Clean
- * Architecture — no Zod, Supabase, or Hono imports here.
- *
- * Nullability convention: `lookingFor.religionRequired` and `lookingFor.wantsChildren`
- * explicitly allow `null` to encode "no requirement." All other fields use optional
- * (`?`) — omitted means "not specified."
- */
+/** Preferences value object — framework-free aboutMe / lookingFor / dealBreakers shape. */
 import { DomainError } from './errors.js'
 
 export class InvalidPreferencesError extends DomainError {
@@ -69,6 +59,8 @@ export interface Preferences {
 
 export type PreferencesInput = Preferences
 
+type Mutable<T> = { -readonly [K in keyof T]: T[K] }
+
 const BUILDS: readonly Build[] = ['slim', 'average', 'athletic', 'heavy']
 const FITNESS_LEVELS: readonly FitnessLevel[] = ['active', 'average', 'sedentary']
 const INCOMES: readonly Income[] = ['high', 'moderate', 'low']
@@ -98,10 +90,7 @@ function validateAboutMe(aboutMe: AboutMe): AboutMe {
 	}
 
 	if (aboutMe.numberOfChildren !== undefined) {
-		if (
-			!Number.isInteger(aboutMe.numberOfChildren) ||
-			(aboutMe.numberOfChildren as number) < 0
-		) {
+		if (!Number.isInteger(aboutMe.numberOfChildren) || aboutMe.numberOfChildren < 0) {
 			invalid(
 				'INVALID_PREFERENCES_NUMBER_OF_CHILDREN',
 				'aboutMe.numberOfChildren must be a non-negative integer',
@@ -124,11 +113,27 @@ function validateAboutMe(aboutMe: AboutMe): AboutMe {
 		invalid('INVALID_PREFERENCES_INCOME', `aboutMe.income must be one of ${INCOMES.join(', ')}`)
 	}
 
-	return Object.freeze({ ...aboutMe })
+	// Whitelist-copy known keys so unknown runtime keys are dropped (symmetric with
+	// the top-level behavior in createPreferences).
+	const out: Mutable<AboutMe> = {}
+	if (aboutMe.height !== undefined) out.height = aboutMe.height
+	if (aboutMe.build !== undefined) out.build = aboutMe.build
+	if (aboutMe.fitnessLevel !== undefined) out.fitnessLevel = aboutMe.fitnessLevel
+	if (aboutMe.ethnicity !== undefined) out.ethnicity = aboutMe.ethnicity
+	if (aboutMe.religion !== undefined) out.religion = aboutMe.religion
+	if (aboutMe.hasChildren !== undefined) out.hasChildren = aboutMe.hasChildren
+	if (aboutMe.numberOfChildren !== undefined) out.numberOfChildren = aboutMe.numberOfChildren
+	if (aboutMe.isDivorced !== undefined) out.isDivorced = aboutMe.isDivorced
+	if (aboutMe.hasTattoos !== undefined) out.hasTattoos = aboutMe.hasTattoos
+	if (aboutMe.hasPiercings !== undefined) out.hasPiercings = aboutMe.hasPiercings
+	if (aboutMe.isSmoker !== undefined) out.isSmoker = aboutMe.isSmoker
+	if (aboutMe.occupation !== undefined) out.occupation = aboutMe.occupation
+	if (aboutMe.income !== undefined) out.income = aboutMe.income
+	return Object.freeze(out)
 }
 
 function validateRange(range: Range, label: string): Range {
-	let { min, max } = range
+	const { min, max } = range
 
 	if (min !== undefined) {
 		if (!isFiniteNumber(min) || min < 0) {
@@ -152,19 +157,14 @@ function validateRange(range: Range, label: string): Range {
 		invalid('INVALID_PREFERENCES_RANGE_ORDER', `${label}.min must be <= ${label}.max`)
 	}
 
-	return Object.freeze({ ...range })
+	const out: Mutable<Range> = {}
+	if (min !== undefined) out.min = min
+	if (max !== undefined) out.max = max
+	return Object.freeze(out)
 }
 
 function validateLookingFor(lookingFor: LookingFor): LookingFor {
-	let out: {
-		ageRange?: Range
-		heightRange?: Range
-		fitnessPreference?: FitnessPreference
-		ethnicityPreference?: readonly string[]
-		incomePreference?: IncomePreference
-		religionRequired?: string | null
-		wantsChildren?: boolean | null
-	} = {}
+	const out: Mutable<LookingFor> = {}
 
 	if (lookingFor.ageRange !== undefined) {
 		out.ageRange = validateRange(lookingFor.ageRange, 'lookingFor.ageRange')
@@ -195,7 +195,7 @@ function validateLookingFor(lookingFor: LookingFor): LookingFor {
 	}
 
 	if (lookingFor.ethnicityPreference !== undefined) {
-		for (let entry of lookingFor.ethnicityPreference) {
+		for (const entry of lookingFor.ethnicityPreference) {
 			if (typeof entry !== 'string') {
 				invalid(
 					'INVALID_PREFERENCES_ETHNICITY_PREFERENCE',
@@ -218,8 +218,8 @@ function validateLookingFor(lookingFor: LookingFor): LookingFor {
 }
 
 function validateDealBreakers(dealBreakers: readonly DealBreaker[]): readonly DealBreaker[] {
-	let seen = new Set<DealBreaker>()
-	for (let entry of dealBreakers) {
+	const seen = new Set<DealBreaker>()
+	for (const entry of dealBreakers) {
 		if (!DEAL_BREAKERS.includes(entry)) {
 			invalid(
 				'INVALID_PREFERENCES_DEAL_BREAKER',
@@ -238,11 +238,7 @@ function validateDealBreakers(dealBreakers: readonly DealBreaker[]): readonly De
 }
 
 export function createPreferences(input: PreferencesInput): Preferences {
-	let out: {
-		aboutMe?: AboutMe
-		lookingFor?: LookingFor
-		dealBreakers?: readonly DealBreaker[]
-	} = {}
+	const out: Mutable<Preferences> = {}
 
 	if (input.aboutMe !== undefined) {
 		out.aboutMe = validateAboutMe(input.aboutMe)

--- a/packages/shared/src/domain/preferences.ts
+++ b/packages/shared/src/domain/preferences.ts
@@ -1,0 +1,74 @@
+/**
+ * Preferences value object for the domain layer.
+ *
+ * Framework-free representation of a person's self-description (aboutMe),
+ * candidate preferences (lookingFor), and deal breakers. Part of Clean
+ * Architecture — no Zod, Supabase, or Hono imports here.
+ *
+ * Nullability convention: `lookingFor.religionRequired` and `lookingFor.wantsChildren`
+ * explicitly allow `null` to encode "no requirement." All other fields use optional
+ * (`?`) — omitted means "not specified."
+ */
+import { DomainError } from './errors.js'
+
+export class InvalidPreferencesError extends DomainError {
+	constructor(code: string, message: string) {
+		super(code, message)
+		this.name = 'InvalidPreferencesError'
+	}
+}
+
+export type Build = 'slim' | 'average' | 'athletic' | 'heavy'
+export type FitnessLevel = 'active' | 'average' | 'sedentary'
+export type Income = 'high' | 'moderate' | 'low'
+export type FitnessPreference = 'active' | 'average' | 'any'
+export type IncomePreference = 'high' | 'moderate' | 'any'
+export type DealBreaker =
+	| 'isDivorced'
+	| 'hasChildren'
+	| 'hasTattoos'
+	| 'hasPiercings'
+	| 'isSmoker'
+
+export interface AboutMe {
+	readonly height?: number
+	readonly build?: Build
+	readonly fitnessLevel?: FitnessLevel
+	readonly ethnicity?: string
+	readonly religion?: string
+	readonly hasChildren?: boolean
+	readonly numberOfChildren?: number
+	readonly isDivorced?: boolean
+	readonly hasTattoos?: boolean
+	readonly hasPiercings?: boolean
+	readonly isSmoker?: boolean
+	readonly occupation?: string
+	readonly income?: Income
+}
+
+export interface Range {
+	readonly min?: number
+	readonly max?: number
+}
+
+export interface LookingFor {
+	readonly ageRange?: Range
+	readonly heightRange?: Range
+	readonly fitnessPreference?: FitnessPreference
+	readonly ethnicityPreference?: readonly string[]
+	readonly incomePreference?: IncomePreference
+	readonly religionRequired?: string | null
+	readonly wantsChildren?: boolean | null
+}
+
+export interface Preferences {
+	readonly aboutMe?: AboutMe
+	readonly lookingFor?: LookingFor
+	readonly dealBreakers?: readonly DealBreaker[]
+}
+
+export type PreferencesInput = Preferences
+
+export function createPreferences(_input: PreferencesInput): Preferences {
+	throw new Error('Not implemented')
+}

--- a/packages/shared/src/domain/preferences.ts
+++ b/packages/shared/src/domain/preferences.ts
@@ -61,12 +61,12 @@ export type PreferencesInput = Preferences
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] }
 
-const BUILDS: readonly Build[] = ['slim', 'average', 'athletic', 'heavy']
-const FITNESS_LEVELS: readonly FitnessLevel[] = ['active', 'average', 'sedentary']
-const INCOMES: readonly Income[] = ['high', 'moderate', 'low']
-const FITNESS_PREFERENCES: readonly FitnessPreference[] = ['active', 'average', 'any']
-const INCOME_PREFERENCES: readonly IncomePreference[] = ['high', 'moderate', 'any']
-const DEAL_BREAKERS: readonly DealBreaker[] = [
+let BUILDS: readonly Build[] = ['slim', 'average', 'athletic', 'heavy']
+let FITNESS_LEVELS: readonly FitnessLevel[] = ['active', 'average', 'sedentary']
+let INCOMES: readonly Income[] = ['high', 'moderate', 'low']
+let FITNESS_PREFERENCES: readonly FitnessPreference[] = ['active', 'average', 'any']
+let INCOME_PREFERENCES: readonly IncomePreference[] = ['high', 'moderate', 'any']
+let DEAL_BREAKERS: readonly DealBreaker[] = [
 	'isDivorced',
 	'hasChildren',
 	'hasTattoos',
@@ -115,7 +115,7 @@ function validateAboutMe(aboutMe: AboutMe): AboutMe {
 
 	// Whitelist-copy known keys so unknown runtime keys are dropped (symmetric with
 	// the top-level behavior in createPreferences).
-	const out: Mutable<AboutMe> = {}
+	let out: Mutable<AboutMe> = {}
 	if (aboutMe.height !== undefined) out.height = aboutMe.height
 	if (aboutMe.build !== undefined) out.build = aboutMe.build
 	if (aboutMe.fitnessLevel !== undefined) out.fitnessLevel = aboutMe.fitnessLevel
@@ -133,7 +133,7 @@ function validateAboutMe(aboutMe: AboutMe): AboutMe {
 }
 
 function validateRange(range: Range, label: string): Range {
-	const { min, max } = range
+	let { min, max } = range
 
 	if (min !== undefined) {
 		if (!isFiniteNumber(min) || min < 0) {
@@ -157,14 +157,14 @@ function validateRange(range: Range, label: string): Range {
 		invalid('INVALID_PREFERENCES_RANGE_ORDER', `${label}.min must be <= ${label}.max`)
 	}
 
-	const out: Mutable<Range> = {}
+	let out: Mutable<Range> = {}
 	if (min !== undefined) out.min = min
 	if (max !== undefined) out.max = max
 	return Object.freeze(out)
 }
 
 function validateLookingFor(lookingFor: LookingFor): LookingFor {
-	const out: Mutable<LookingFor> = {}
+	let out: Mutable<LookingFor> = {}
 
 	if (lookingFor.ageRange !== undefined) {
 		out.ageRange = validateRange(lookingFor.ageRange, 'lookingFor.ageRange')
@@ -195,7 +195,7 @@ function validateLookingFor(lookingFor: LookingFor): LookingFor {
 	}
 
 	if (lookingFor.ethnicityPreference !== undefined) {
-		for (const entry of lookingFor.ethnicityPreference) {
+		for (let entry of lookingFor.ethnicityPreference) {
 			if (typeof entry !== 'string') {
 				invalid(
 					'INVALID_PREFERENCES_ETHNICITY_PREFERENCE',
@@ -218,8 +218,8 @@ function validateLookingFor(lookingFor: LookingFor): LookingFor {
 }
 
 function validateDealBreakers(dealBreakers: readonly DealBreaker[]): readonly DealBreaker[] {
-	const seen = new Set<DealBreaker>()
-	for (const entry of dealBreakers) {
+	let seen = new Set<DealBreaker>()
+	for (let entry of dealBreakers) {
 		if (!DEAL_BREAKERS.includes(entry)) {
 			invalid(
 				'INVALID_PREFERENCES_DEAL_BREAKER',
@@ -238,7 +238,7 @@ function validateDealBreakers(dealBreakers: readonly DealBreaker[]): readonly De
 }
 
 export function createPreferences(input: PreferencesInput): Preferences {
-	const out: Mutable<Preferences> = {}
+	let out: Mutable<Preferences> = {}
 
 	if (input.aboutMe !== undefined) {
 		out.aboutMe = validateAboutMe(input.aboutMe)

--- a/packages/shared/src/domain/preferences.ts
+++ b/packages/shared/src/domain/preferences.ts
@@ -69,6 +69,192 @@ export interface Preferences {
 
 export type PreferencesInput = Preferences
 
-export function createPreferences(_input: PreferencesInput): Preferences {
-	throw new Error('Not implemented')
+const BUILDS: readonly Build[] = ['slim', 'average', 'athletic', 'heavy']
+const FITNESS_LEVELS: readonly FitnessLevel[] = ['active', 'average', 'sedentary']
+const INCOMES: readonly Income[] = ['high', 'moderate', 'low']
+const FITNESS_PREFERENCES: readonly FitnessPreference[] = ['active', 'average', 'any']
+const INCOME_PREFERENCES: readonly IncomePreference[] = ['high', 'moderate', 'any']
+const DEAL_BREAKERS: readonly DealBreaker[] = [
+	'isDivorced',
+	'hasChildren',
+	'hasTattoos',
+	'hasPiercings',
+	'isSmoker',
+]
+
+function invalid(code: string, message: string): never {
+	throw new InvalidPreferencesError(code, message)
+}
+
+function isFiniteNumber(value: unknown): value is number {
+	return typeof value === 'number' && Number.isFinite(value)
+}
+
+function validateAboutMe(aboutMe: AboutMe): AboutMe {
+	if (aboutMe.height !== undefined) {
+		if (!isFiniteNumber(aboutMe.height) || aboutMe.height <= 0) {
+			invalid('INVALID_PREFERENCES_HEIGHT', 'aboutMe.height must be a positive finite number')
+		}
+	}
+
+	if (aboutMe.numberOfChildren !== undefined) {
+		if (
+			!Number.isInteger(aboutMe.numberOfChildren) ||
+			(aboutMe.numberOfChildren as number) < 0
+		) {
+			invalid(
+				'INVALID_PREFERENCES_NUMBER_OF_CHILDREN',
+				'aboutMe.numberOfChildren must be a non-negative integer',
+			)
+		}
+	}
+
+	if (aboutMe.build !== undefined && !BUILDS.includes(aboutMe.build)) {
+		invalid('INVALID_PREFERENCES_BUILD', `aboutMe.build must be one of ${BUILDS.join(', ')}`)
+	}
+
+	if (aboutMe.fitnessLevel !== undefined && !FITNESS_LEVELS.includes(aboutMe.fitnessLevel)) {
+		invalid(
+			'INVALID_PREFERENCES_FITNESS_LEVEL',
+			`aboutMe.fitnessLevel must be one of ${FITNESS_LEVELS.join(', ')}`,
+		)
+	}
+
+	if (aboutMe.income !== undefined && !INCOMES.includes(aboutMe.income)) {
+		invalid('INVALID_PREFERENCES_INCOME', `aboutMe.income must be one of ${INCOMES.join(', ')}`)
+	}
+
+	return Object.freeze({ ...aboutMe })
+}
+
+function validateRange(range: Range, label: string): Range {
+	let { min, max } = range
+
+	if (min !== undefined) {
+		if (!isFiniteNumber(min) || min < 0) {
+			invalid(
+				'INVALID_PREFERENCES_RANGE_MIN',
+				`${label}.min must be a non-negative finite number`,
+			)
+		}
+	}
+
+	if (max !== undefined) {
+		if (!isFiniteNumber(max) || max < 0) {
+			invalid(
+				'INVALID_PREFERENCES_RANGE_MAX',
+				`${label}.max must be a non-negative finite number`,
+			)
+		}
+	}
+
+	if (min !== undefined && max !== undefined && min > max) {
+		invalid('INVALID_PREFERENCES_RANGE_ORDER', `${label}.min must be <= ${label}.max`)
+	}
+
+	return Object.freeze({ ...range })
+}
+
+function validateLookingFor(lookingFor: LookingFor): LookingFor {
+	let out: {
+		ageRange?: Range
+		heightRange?: Range
+		fitnessPreference?: FitnessPreference
+		ethnicityPreference?: readonly string[]
+		incomePreference?: IncomePreference
+		religionRequired?: string | null
+		wantsChildren?: boolean | null
+	} = {}
+
+	if (lookingFor.ageRange !== undefined) {
+		out.ageRange = validateRange(lookingFor.ageRange, 'lookingFor.ageRange')
+	}
+
+	if (lookingFor.heightRange !== undefined) {
+		out.heightRange = validateRange(lookingFor.heightRange, 'lookingFor.heightRange')
+	}
+
+	if (lookingFor.fitnessPreference !== undefined) {
+		if (!FITNESS_PREFERENCES.includes(lookingFor.fitnessPreference)) {
+			invalid(
+				'INVALID_PREFERENCES_FITNESS_PREFERENCE',
+				`lookingFor.fitnessPreference must be one of ${FITNESS_PREFERENCES.join(', ')}`,
+			)
+		}
+		out.fitnessPreference = lookingFor.fitnessPreference
+	}
+
+	if (lookingFor.incomePreference !== undefined) {
+		if (!INCOME_PREFERENCES.includes(lookingFor.incomePreference)) {
+			invalid(
+				'INVALID_PREFERENCES_INCOME_PREFERENCE',
+				`lookingFor.incomePreference must be one of ${INCOME_PREFERENCES.join(', ')}`,
+			)
+		}
+		out.incomePreference = lookingFor.incomePreference
+	}
+
+	if (lookingFor.ethnicityPreference !== undefined) {
+		for (let entry of lookingFor.ethnicityPreference) {
+			if (typeof entry !== 'string') {
+				invalid(
+					'INVALID_PREFERENCES_ETHNICITY_PREFERENCE',
+					'lookingFor.ethnicityPreference must contain only strings',
+				)
+			}
+		}
+		out.ethnicityPreference = Object.freeze([...lookingFor.ethnicityPreference])
+	}
+
+	if (lookingFor.religionRequired !== undefined) {
+		out.religionRequired = lookingFor.religionRequired
+	}
+
+	if (lookingFor.wantsChildren !== undefined) {
+		out.wantsChildren = lookingFor.wantsChildren
+	}
+
+	return Object.freeze(out)
+}
+
+function validateDealBreakers(dealBreakers: readonly DealBreaker[]): readonly DealBreaker[] {
+	let seen = new Set<DealBreaker>()
+	for (let entry of dealBreakers) {
+		if (!DEAL_BREAKERS.includes(entry)) {
+			invalid(
+				'INVALID_PREFERENCES_DEAL_BREAKER',
+				`dealBreakers must contain only known literals; got "${String(entry)}"`,
+			)
+		}
+		if (seen.has(entry)) {
+			invalid(
+				'INVALID_PREFERENCES_DEAL_BREAKER_DUPLICATE',
+				`dealBreakers must not contain duplicates; got "${entry}"`,
+			)
+		}
+		seen.add(entry)
+	}
+	return Object.freeze([...dealBreakers])
+}
+
+export function createPreferences(input: PreferencesInput): Preferences {
+	let out: {
+		aboutMe?: AboutMe
+		lookingFor?: LookingFor
+		dealBreakers?: readonly DealBreaker[]
+	} = {}
+
+	if (input.aboutMe !== undefined) {
+		out.aboutMe = validateAboutMe(input.aboutMe)
+	}
+
+	if (input.lookingFor !== undefined) {
+		out.lookingFor = validateLookingFor(input.lookingFor)
+	}
+
+	if (input.dealBreakers !== undefined) {
+		out.dealBreakers = validateDealBreakers(input.dealBreakers)
+	}
+
+	return Object.freeze(out)
 }

--- a/packages/shared/src/domain/validators.ts
+++ b/packages/shared/src/domain/validators.ts
@@ -1,0 +1,26 @@
+import { DomainError } from './errors.js'
+
+type DomainErrorCtor<E extends DomainError> = new (code: string, message: string) => E
+
+export function requireNonEmptyString<E extends DomainError>(
+	value: unknown,
+	field: string,
+	code: string,
+	ErrorClass: DomainErrorCtor<E>,
+): string {
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		throw new ErrorClass(code, `${field} must be a non-empty string`)
+	}
+	return value.trim()
+}
+
+export function assertValidDate<E extends DomainError>(
+	value: unknown,
+	field: string,
+	code: string,
+	ErrorClass: DomainErrorCtor<E>,
+): asserts value is Date {
+	if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+		throw new ErrorClass(code, `${field} must be a valid Date`)
+	}
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export { MATCHMAKER_INTERVIEW_TEXT } from './matchmaker-interview-prompt.js'
 export { prompts, getPrompt, type Prompt } from './prompts.js'
 export type { GetPromptResult, PromptMessage } from './prompts.js'
+export * from './domain/index.js'

--- a/packages/shared/tests/domain/introduction.test.ts
+++ b/packages/shared/tests/domain/introduction.test.ts
@@ -1,0 +1,169 @@
+import { describe, test, expect } from 'bun:test'
+import {
+	createIntroduction,
+	InvalidIntroductionError,
+	type IntroductionInput,
+	type IntroductionStatus,
+} from '../../src/domain/introduction'
+import { DomainError } from '../../src/domain/errors'
+
+function baseInput(overrides: Partial<IntroductionInput> = {}): IntroductionInput {
+	return {
+		id: 'intro-1',
+		matchmakerAId: 'mm-a',
+		matchmakerBId: 'mm-b',
+		personAId: 'person-a',
+		personBId: 'person-b',
+		createdAt: new Date('2026-01-01T00:00:00Z'),
+		updatedAt: new Date('2026-01-01T00:00:00Z'),
+		...overrides,
+	}
+}
+
+describe('createIntroduction', () => {
+	describe('happy path', () => {
+		test('returns a frozen Introduction with all fields populated', () => {
+			let result = createIntroduction({
+				id: 'intro-1',
+				matchmakerAId: 'mm-a',
+				matchmakerBId: 'mm-b',
+				personAId: 'person-a',
+				personBId: 'person-b',
+				status: 'dating',
+				notes: 'hit it off at coffee',
+				createdAt: new Date('2026-01-01T00:00:00Z'),
+				updatedAt: new Date('2026-01-03T00:00:00Z'),
+			})
+
+			expect(result.id).toBe('intro-1')
+			expect(result.status).toBe('dating')
+			expect(result.notes).toBe('hit it off at coffee')
+			expect(Object.isFrozen(result)).toBe(true)
+		})
+
+		test('defaults status to pending when omitted', () => {
+			let result = createIntroduction(baseInput())
+			expect(result.status).toBe('pending')
+		})
+
+		test('accepts all five valid status literals', () => {
+			let statuses: IntroductionStatus[] = [
+				'pending',
+				'accepted',
+				'declined',
+				'dating',
+				'ended',
+			]
+			for (let s of statuses) {
+				let result = createIntroduction(baseInput({ status: s }))
+				expect(result.status).toBe(s)
+			}
+		})
+
+		test('normalizes omitted notes to null', () => {
+			let result = createIntroduction(baseInput())
+			expect(result.notes).toBeNull()
+		})
+
+		test('allows matchmakerAId to equal matchmakerBId', () => {
+			let result = createIntroduction(
+				baseInput({ matchmakerAId: 'mm-same', matchmakerBId: 'mm-same' }),
+			)
+			expect(result.matchmakerAId).toBe('mm-same')
+			expect(result.matchmakerBId).toBe('mm-same')
+		})
+	})
+
+	describe('id invariants', () => {
+		test('throws InvalidIntroductionError when id is empty', () => {
+			expect(() => createIntroduction(baseInput({ id: '' }))).toThrow(InvalidIntroductionError)
+		})
+
+		test('throws InvalidIntroductionError when matchmakerAId is empty', () => {
+			expect(() => createIntroduction(baseInput({ matchmakerAId: '' }))).toThrow(
+				InvalidIntroductionError,
+			)
+		})
+
+		test('throws InvalidIntroductionError when matchmakerBId is empty', () => {
+			expect(() => createIntroduction(baseInput({ matchmakerBId: '' }))).toThrow(
+				InvalidIntroductionError,
+			)
+		})
+
+		test('throws InvalidIntroductionError when personAId is empty', () => {
+			expect(() => createIntroduction(baseInput({ personAId: '' }))).toThrow(
+				InvalidIntroductionError,
+			)
+		})
+
+		test('throws InvalidIntroductionError when personBId is empty', () => {
+			expect(() => createIntroduction(baseInput({ personBId: '' }))).toThrow(
+				InvalidIntroductionError,
+			)
+		})
+	})
+
+	describe('self-introduction invariant', () => {
+		test('throws InvalidIntroductionError when personAId equals personBId', () => {
+			expect(() =>
+				createIntroduction(baseInput({ personAId: 'same', personBId: 'same' })),
+			).toThrow(InvalidIntroductionError)
+		})
+	})
+
+	describe('status invariants', () => {
+		test('throws InvalidIntroductionError when status is not a known literal', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of invalid literal
+				createIntroduction(baseInput({ status: 'unknown' })),
+			).toThrow(InvalidIntroductionError)
+		})
+	})
+
+	describe('timestamp invariants', () => {
+		test('throws InvalidIntroductionError when createdAt is an Invalid Date', () => {
+			expect(() =>
+				createIntroduction(baseInput({ createdAt: new Date('not-a-date') })),
+			).toThrow(InvalidIntroductionError)
+		})
+
+		test('throws InvalidIntroductionError when updatedAt is before createdAt', () => {
+			expect(() =>
+				createIntroduction(
+					baseInput({
+						createdAt: new Date('2026-01-02T00:00:00Z'),
+						updatedAt: new Date('2026-01-01T00:00:00Z'),
+					}),
+				),
+			).toThrow(InvalidIntroductionError)
+		})
+	})
+
+	describe('error shape', () => {
+		test('InvalidIntroductionError extends DomainError', () => {
+			let err: unknown = null
+			try {
+				createIntroduction(baseInput({ id: '' }))
+			} catch (e) {
+				err = e
+			}
+			expect(err).toBeInstanceOf(InvalidIntroductionError)
+			expect(err).toBeInstanceOf(DomainError)
+		})
+
+		test('InvalidIntroductionError has a stable code string', () => {
+			let err: unknown = null
+			try {
+				createIntroduction(baseInput({ id: '' }))
+			} catch (e) {
+				err = e
+			}
+			expect(err).toBeInstanceOf(InvalidIntroductionError)
+			if (err instanceof InvalidIntroductionError) {
+				expect(typeof err.code).toBe('string')
+				expect(err.code.length).toBeGreaterThan(0)
+			}
+		})
+	})
+})

--- a/packages/shared/tests/domain/match-decision.test.ts
+++ b/packages/shared/tests/domain/match-decision.test.ts
@@ -100,16 +100,39 @@ describe('createMatchDecision', () => {
 			).toThrow(InvalidMatchDecisionError)
 		})
 
-		test('throws InvalidMatchDecisionError when decision is declined and declineReason is an empty string', () => {
-			expect(() =>
-				createMatchDecision(baseInput({ decision: 'declined', declineReason: '' })),
-			).toThrow(InvalidMatchDecisionError)
+		test('normalizes empty-string declineReason to null on an accepted decision', () => {
+			let result = createMatchDecision(
+				baseInput({ decision: 'accepted', declineReason: '' }),
+			)
+			expect(result.declineReason).toBeNull()
 		})
 
-		test('throws InvalidMatchDecisionError when decision is declined and declineReason is whitespace', () => {
-			expect(() =>
-				createMatchDecision(baseInput({ decision: 'declined', declineReason: '   ' })),
-			).toThrow(InvalidMatchDecisionError)
+		test('normalizes whitespace declineReason to null on an accepted decision', () => {
+			let result = createMatchDecision(
+				baseInput({ decision: 'accepted', declineReason: '   ' }),
+			)
+			expect(result.declineReason).toBeNull()
+		})
+
+		test('normalizes empty-string declineReason to null on a declined decision', () => {
+			let result = createMatchDecision(
+				baseInput({ decision: 'declined', declineReason: '' }),
+			)
+			expect(result.declineReason).toBeNull()
+		})
+
+		test('normalizes whitespace declineReason to null on a declined decision', () => {
+			let result = createMatchDecision(
+				baseInput({ decision: 'declined', declineReason: '   ' }),
+			)
+			expect(result.declineReason).toBeNull()
+		})
+
+		test('trims surrounding whitespace on a non-empty declineReason', () => {
+			let result = createMatchDecision(
+				baseInput({ decision: 'declined', declineReason: '  incompatible schedules  ' }),
+			)
+			expect(result.declineReason).toBe('incompatible schedules')
 		})
 
 		test('accepts a declined decision with a non-empty declineReason', () => {

--- a/packages/shared/tests/domain/match-decision.test.ts
+++ b/packages/shared/tests/domain/match-decision.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect } from 'bun:test'
+import {
+	createMatchDecision,
+	InvalidMatchDecisionError,
+	type MatchDecisionInput,
+} from '../../src/domain/match-decision'
+import { DomainError } from '../../src/domain/errors'
+
+function baseInput(overrides: Partial<MatchDecisionInput> = {}): MatchDecisionInput {
+	return {
+		id: 'decision-1',
+		matchmakerId: 'mm-1',
+		personId: 'person-a',
+		candidateId: 'person-b',
+		decision: 'accepted',
+		createdAt: new Date('2026-01-01T00:00:00Z'),
+		...overrides,
+	}
+}
+
+describe('createMatchDecision', () => {
+	describe('happy path', () => {
+		test('returns a frozen MatchDecision for an accepted decision without reason', () => {
+			let result = createMatchDecision(baseInput({ decision: 'accepted' }))
+			expect(result.decision).toBe('accepted')
+			expect(result.declineReason).toBeNull()
+			expect(Object.isFrozen(result)).toBe(true)
+		})
+
+		test('returns a frozen MatchDecision for a declined decision with a reason', () => {
+			let result = createMatchDecision(
+				baseInput({ decision: 'declined', declineReason: 'different life goals' }),
+			)
+			expect(result.decision).toBe('declined')
+			expect(result.declineReason).toBe('different life goals')
+			expect(Object.isFrozen(result)).toBe(true)
+		})
+
+		test('returns a frozen MatchDecision for a declined decision without a reason', () => {
+			let result = createMatchDecision(baseInput({ decision: 'declined' }))
+			expect(result.decision).toBe('declined')
+			expect(result.declineReason).toBeNull()
+		})
+
+		test('normalizes omitted declineReason to null', () => {
+			let result = createMatchDecision(baseInput({ decision: 'accepted' }))
+			expect(result.declineReason).toBeNull()
+		})
+	})
+
+	describe('id invariants', () => {
+		test('throws InvalidMatchDecisionError when id is empty', () => {
+			expect(() => createMatchDecision(baseInput({ id: '' }))).toThrow(
+				InvalidMatchDecisionError,
+			)
+		})
+
+		test('throws InvalidMatchDecisionError when matchmakerId is empty', () => {
+			expect(() => createMatchDecision(baseInput({ matchmakerId: '' }))).toThrow(
+				InvalidMatchDecisionError,
+			)
+		})
+
+		test('throws InvalidMatchDecisionError when personId is empty', () => {
+			expect(() => createMatchDecision(baseInput({ personId: '' }))).toThrow(
+				InvalidMatchDecisionError,
+			)
+		})
+
+		test('throws InvalidMatchDecisionError when candidateId is empty', () => {
+			expect(() => createMatchDecision(baseInput({ candidateId: '' }))).toThrow(
+				InvalidMatchDecisionError,
+			)
+		})
+	})
+
+	describe('self-match invariant', () => {
+		test('throws InvalidMatchDecisionError when personId equals candidateId', () => {
+			expect(() =>
+				createMatchDecision(baseInput({ personId: 'same', candidateId: 'same' })),
+			).toThrow(InvalidMatchDecisionError)
+		})
+	})
+
+	describe('decision invariants', () => {
+		test('throws InvalidMatchDecisionError when decision is not a known literal', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of invalid literal
+				createMatchDecision(baseInput({ decision: 'maybe' })),
+			).toThrow(InvalidMatchDecisionError)
+		})
+	})
+
+	describe('decline reason coupling', () => {
+		test('throws InvalidMatchDecisionError when decision is accepted and declineReason is a non-empty string', () => {
+			expect(() =>
+				createMatchDecision(
+					baseInput({ decision: 'accepted', declineReason: 'should not be here' }),
+				),
+			).toThrow(InvalidMatchDecisionError)
+		})
+
+		test('throws InvalidMatchDecisionError when decision is declined and declineReason is an empty string', () => {
+			expect(() =>
+				createMatchDecision(baseInput({ decision: 'declined', declineReason: '' })),
+			).toThrow(InvalidMatchDecisionError)
+		})
+
+		test('throws InvalidMatchDecisionError when decision is declined and declineReason is whitespace', () => {
+			expect(() =>
+				createMatchDecision(baseInput({ decision: 'declined', declineReason: '   ' })),
+			).toThrow(InvalidMatchDecisionError)
+		})
+
+		test('accepts a declined decision with a non-empty declineReason', () => {
+			let result = createMatchDecision(
+				baseInput({ decision: 'declined', declineReason: 'incompatible schedules' }),
+			)
+			expect(result.declineReason).toBe('incompatible schedules')
+		})
+	})
+
+	describe('timestamp invariants', () => {
+		test('throws InvalidMatchDecisionError when createdAt is an Invalid Date', () => {
+			expect(() =>
+				createMatchDecision(baseInput({ createdAt: new Date('not-a-date') })),
+			).toThrow(InvalidMatchDecisionError)
+		})
+	})
+
+	describe('error shape', () => {
+		test('InvalidMatchDecisionError extends DomainError', () => {
+			let err: unknown = null
+			try {
+				createMatchDecision(baseInput({ id: '' }))
+			} catch (e) {
+				err = e
+			}
+			expect(err).toBeInstanceOf(InvalidMatchDecisionError)
+			expect(err).toBeInstanceOf(DomainError)
+		})
+
+		test('InvalidMatchDecisionError has a stable code string', () => {
+			let err: unknown = null
+			try {
+				createMatchDecision(baseInput({ id: '' }))
+			} catch (e) {
+				err = e
+			}
+			expect(err).toBeInstanceOf(InvalidMatchDecisionError)
+			if (err instanceof InvalidMatchDecisionError) {
+				expect(typeof err.code).toBe('string')
+				expect(err.code.length).toBeGreaterThan(0)
+			}
+		})
+	})
+})

--- a/packages/shared/tests/domain/person.test.ts
+++ b/packages/shared/tests/domain/person.test.ts
@@ -1,0 +1,194 @@
+import { describe, test, expect } from 'bun:test'
+import {
+	createPerson,
+	InvalidPersonError,
+	type PersonInput,
+} from '../../src/domain/person'
+import { DomainError } from '../../src/domain/errors'
+
+function baseInput(overrides: Partial<PersonInput> = {}): PersonInput {
+	return {
+		id: 'person-1',
+		name: 'Alice',
+		createdAt: new Date('2026-01-01T00:00:00Z'),
+		updatedAt: new Date('2026-01-01T00:00:00Z'),
+		...overrides,
+	}
+}
+
+describe('createPerson', () => {
+	describe('happy path', () => {
+		test('returns a frozen Person with all fields populated', () => {
+			let result = createPerson({
+				id: 'person-1',
+				matchmakerId: 'mm-1',
+				name: 'Alice',
+				age: 30,
+				location: 'NYC',
+				gender: 'female',
+				preferences: { build: 'athletic' },
+				personality: { traits: ['curious'] },
+				notes: 'met at conference',
+				active: true,
+				createdAt: new Date('2026-01-01T00:00:00Z'),
+				updatedAt: new Date('2026-01-02T00:00:00Z'),
+			})
+
+			expect(result.id).toBe('person-1')
+			expect(result.matchmakerId).toBe('mm-1')
+			expect(result.name).toBe('Alice')
+			expect(result.age).toBe(30)
+			expect(result.location).toBe('NYC')
+			expect(result.gender).toBe('female')
+			expect(result.preferences).toEqual({ build: 'athletic' })
+			expect(result.personality).toEqual({ traits: ['curious'] })
+			expect(result.notes).toBe('met at conference')
+			expect(result.active).toBe(true)
+			expect(Object.isFrozen(result)).toBe(true)
+		})
+
+		test('defaults active to true when omitted', () => {
+			let result = createPerson(baseInput())
+			expect(result.active).toBe(true)
+		})
+
+		test('preserves active=false when provided', () => {
+			let result = createPerson(baseInput({ active: false }))
+			expect(result.active).toBe(false)
+		})
+
+		test('normalizes omitted optional fields to null', () => {
+			let result = createPerson(baseInput())
+			expect(result.matchmakerId).toBeNull()
+			expect(result.age).toBeNull()
+			expect(result.location).toBeNull()
+			expect(result.gender).toBeNull()
+			expect(result.preferences).toBeNull()
+			expect(result.personality).toBeNull()
+			expect(result.notes).toBeNull()
+		})
+
+		test('normalizes matchmakerId undefined to null', () => {
+			let result = createPerson(baseInput({ matchmakerId: undefined }))
+			expect(result.matchmakerId).toBeNull()
+		})
+
+		test('preserves a non-null matchmakerId', () => {
+			let result = createPerson(baseInput({ matchmakerId: 'mm-42' }))
+			expect(result.matchmakerId).toBe('mm-42')
+		})
+
+		test('accepts age of exactly 18', () => {
+			let result = createPerson(baseInput({ age: 18 }))
+			expect(result.age).toBe(18)
+		})
+
+		test('accepts age as null', () => {
+			let result = createPerson(baseInput({ age: null }))
+			expect(result.age).toBeNull()
+		})
+	})
+
+	describe('id invariants', () => {
+		test('throws InvalidPersonError when id is empty string', () => {
+			expect(() => createPerson(baseInput({ id: '' }))).toThrow(InvalidPersonError)
+		})
+
+		test('throws InvalidPersonError when id is whitespace only', () => {
+			expect(() => createPerson(baseInput({ id: '   ' }))).toThrow(InvalidPersonError)
+		})
+	})
+
+	describe('name invariants', () => {
+		test('throws InvalidPersonError when name is empty string', () => {
+			expect(() => createPerson(baseInput({ name: '' }))).toThrow(InvalidPersonError)
+		})
+
+		test('throws InvalidPersonError when name is whitespace only', () => {
+			expect(() => createPerson(baseInput({ name: '   ' }))).toThrow(InvalidPersonError)
+		})
+	})
+
+	describe('age invariants', () => {
+		test('throws InvalidPersonError when age is 17', () => {
+			expect(() => createPerson(baseInput({ age: 17 }))).toThrow(InvalidPersonError)
+		})
+
+		test('throws InvalidPersonError when age is negative', () => {
+			expect(() => createPerson(baseInput({ age: -5 }))).toThrow(InvalidPersonError)
+		})
+
+		test('throws InvalidPersonError when age is not an integer', () => {
+			expect(() => createPerson(baseInput({ age: 25.5 }))).toThrow(InvalidPersonError)
+		})
+
+		test('throws InvalidPersonError when age is NaN', () => {
+			expect(() => createPerson(baseInput({ age: Number.NaN }))).toThrow(InvalidPersonError)
+		})
+	})
+
+	describe('matchmakerId invariants', () => {
+		test('throws InvalidPersonError when matchmakerId is empty string', () => {
+			expect(() => createPerson(baseInput({ matchmakerId: '' }))).toThrow(InvalidPersonError)
+		})
+	})
+
+	describe('timestamp invariants', () => {
+		test('throws InvalidPersonError when createdAt is not a Date', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of non-Date value
+				createPerson(baseInput({ createdAt: '2026-01-01' })),
+			).toThrow(InvalidPersonError)
+		})
+
+		test('throws InvalidPersonError when createdAt is an Invalid Date', () => {
+			expect(() => createPerson(baseInput({ createdAt: new Date('not-a-date') }))).toThrow(
+				InvalidPersonError,
+			)
+		})
+
+		test('throws InvalidPersonError when updatedAt is before createdAt', () => {
+			expect(() =>
+				createPerson(
+					baseInput({
+						createdAt: new Date('2026-01-02T00:00:00Z'),
+						updatedAt: new Date('2026-01-01T00:00:00Z'),
+					}),
+				),
+			).toThrow(InvalidPersonError)
+		})
+
+		test('accepts updatedAt equal to createdAt', () => {
+			let t = new Date('2026-01-01T00:00:00Z')
+			let result = createPerson(baseInput({ createdAt: t, updatedAt: t }))
+			expect(result.createdAt.getTime()).toBe(result.updatedAt.getTime())
+		})
+	})
+
+	describe('error shape', () => {
+		test('InvalidPersonError extends DomainError', () => {
+			let err: unknown = null
+			try {
+				createPerson(baseInput({ name: '' }))
+			} catch (e) {
+				err = e
+			}
+			expect(err).toBeInstanceOf(InvalidPersonError)
+			expect(err).toBeInstanceOf(DomainError)
+		})
+
+		test('InvalidPersonError has a stable code string', () => {
+			let err: unknown = null
+			try {
+				createPerson(baseInput({ name: '' }))
+			} catch (e) {
+				err = e
+			}
+			expect(err).toBeInstanceOf(InvalidPersonError)
+			if (err instanceof InvalidPersonError) {
+				expect(typeof err.code).toBe('string')
+				expect(err.code.length).toBeGreaterThan(0)
+			}
+		})
+	})
+})

--- a/packages/shared/tests/domain/preferences.test.ts
+++ b/packages/shared/tests/domain/preferences.test.ts
@@ -71,7 +71,16 @@ describe('createPreferences', () => {
 		test('drops unknown top-level keys silently', () => {
 			// @ts-expect-error — deliberately providing an extra key
 			let result = createPreferences({ aboutMe: { height: 170 }, bogus: 'ignored' })
-			expect((result as Record<string, unknown>).bogus).toBeUndefined()
+			expect(Object.prototype.hasOwnProperty.call(result, 'bogus')).toBe(false)
+			expect(result.aboutMe?.height).toBe(170)
+		})
+
+		test('drops unknown keys inside aboutMe silently', () => {
+			let result = createPreferences({
+				// @ts-expect-error — deliberately providing an extra key inside aboutMe
+				aboutMe: { height: 170, rogue: 'nope' },
+			})
+			expect(Object.prototype.hasOwnProperty.call(result.aboutMe, 'rogue')).toBe(false)
 			expect(result.aboutMe?.height).toBe(170)
 		})
 	})

--- a/packages/shared/tests/domain/preferences.test.ts
+++ b/packages/shared/tests/domain/preferences.test.ts
@@ -144,6 +144,18 @@ describe('createPreferences', () => {
 			).toThrow(InvalidPreferencesError)
 		})
 
+		test('throws InvalidPreferencesError when ageRange.max is negative', () => {
+			expect(() =>
+				createPreferences({ lookingFor: { ageRange: { max: -5 } } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when heightRange.max is NaN', () => {
+			expect(() =>
+				createPreferences({ lookingFor: { heightRange: { max: Number.NaN } } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
 		test('throws InvalidPreferencesError when fitnessPreference is not a known literal', () => {
 			expect(() =>
 				// @ts-expect-error — testing runtime rejection of invalid literal

--- a/packages/shared/tests/domain/preferences.test.ts
+++ b/packages/shared/tests/domain/preferences.test.ts
@@ -1,0 +1,234 @@
+import { describe, test, expect } from 'bun:test'
+import {
+	createPreferences,
+	InvalidPreferencesError,
+	type PreferencesInput,
+} from '../../src/domain/preferences'
+import { DomainError } from '../../src/domain/errors'
+
+describe('createPreferences', () => {
+	describe('happy path', () => {
+		test('returns empty preferences when input is empty object', () => {
+			let result = createPreferences({})
+			expect(result).toEqual({})
+		})
+
+		test('accepts a fully-populated preferences object', () => {
+			let input: PreferencesInput = {
+				aboutMe: {
+					height: 180,
+					build: 'athletic',
+					fitnessLevel: 'active',
+					ethnicity: 'mixed',
+					religion: 'none',
+					hasChildren: false,
+					numberOfChildren: 0,
+					isDivorced: false,
+					hasTattoos: true,
+					hasPiercings: false,
+					isSmoker: false,
+					occupation: 'engineer',
+					income: 'moderate',
+				},
+				lookingFor: {
+					ageRange: { min: 28, max: 38 },
+					heightRange: { min: 160, max: 180 },
+					fitnessPreference: 'active',
+					ethnicityPreference: ['asian', 'latin'],
+					incomePreference: 'any',
+					religionRequired: null,
+					wantsChildren: true,
+				},
+				dealBreakers: ['isSmoker', 'hasChildren'],
+			}
+
+			let result = createPreferences(input)
+
+			expect(result.aboutMe?.build).toBe('athletic')
+			expect(result.lookingFor?.ageRange?.min).toBe(28)
+			expect(result.dealBreakers).toEqual(['isSmoker', 'hasChildren'])
+		})
+
+		test('freezes the returned preferences object', () => {
+			let result = createPreferences({})
+			expect(Object.isFrozen(result)).toBe(true)
+		})
+
+		test('freezes nested aboutMe, lookingFor, and dealBreakers', () => {
+			let result = createPreferences({
+				aboutMe: { height: 175 },
+				lookingFor: { ageRange: { min: 25, max: 35 }, ethnicityPreference: ['asian'] },
+				dealBreakers: ['isSmoker'],
+			})
+
+			expect(Object.isFrozen(result.aboutMe)).toBe(true)
+			expect(Object.isFrozen(result.lookingFor)).toBe(true)
+			expect(Object.isFrozen(result.lookingFor?.ageRange)).toBe(true)
+			expect(Object.isFrozen(result.lookingFor?.ethnicityPreference)).toBe(true)
+			expect(Object.isFrozen(result.dealBreakers)).toBe(true)
+		})
+
+		test('drops unknown top-level keys silently', () => {
+			// @ts-expect-error — deliberately providing an extra key
+			let result = createPreferences({ aboutMe: { height: 170 }, bogus: 'ignored' })
+			expect((result as Record<string, unknown>).bogus).toBeUndefined()
+			expect(result.aboutMe?.height).toBe(170)
+		})
+	})
+
+	describe('aboutMe invariants', () => {
+		test('throws InvalidPreferencesError when height is zero', () => {
+			expect(() => createPreferences({ aboutMe: { height: 0 } })).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when height is negative', () => {
+			expect(() => createPreferences({ aboutMe: { height: -1 } })).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when height is NaN', () => {
+			expect(() => createPreferences({ aboutMe: { height: Number.NaN } })).toThrow(
+				InvalidPreferencesError,
+			)
+		})
+
+		test('throws InvalidPreferencesError when numberOfChildren is negative', () => {
+			expect(() => createPreferences({ aboutMe: { numberOfChildren: -1 } })).toThrow(
+				InvalidPreferencesError,
+			)
+		})
+
+		test('throws InvalidPreferencesError when numberOfChildren is not an integer', () => {
+			expect(() => createPreferences({ aboutMe: { numberOfChildren: 1.5 } })).toThrow(
+				InvalidPreferencesError,
+			)
+		})
+
+		test('throws InvalidPreferencesError when build is not a known literal', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of invalid literal
+				createPreferences({ aboutMe: { build: 'bogus' } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when fitnessLevel is not a known literal', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of invalid literal
+				createPreferences({ aboutMe: { fitnessLevel: 'intense' } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when income is not a known literal', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of invalid literal
+				createPreferences({ aboutMe: { income: 'ultra' } }),
+			).toThrow(InvalidPreferencesError)
+		})
+	})
+
+	describe('lookingFor invariants', () => {
+		test('throws InvalidPreferencesError when ageRange.min > ageRange.max', () => {
+			expect(() =>
+				createPreferences({ lookingFor: { ageRange: { min: 40, max: 30 } } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when ageRange.min is negative', () => {
+			expect(() =>
+				createPreferences({ lookingFor: { ageRange: { min: -1, max: 30 } } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when heightRange.min > heightRange.max', () => {
+			expect(() =>
+				createPreferences({ lookingFor: { heightRange: { min: 200, max: 150 } } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when fitnessPreference is not a known literal', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of invalid literal
+				createPreferences({ lookingFor: { fitnessPreference: 'extreme' } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when incomePreference is not a known literal', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of invalid literal
+				createPreferences({ lookingFor: { incomePreference: 'rich' } }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when ethnicityPreference contains a non-string', () => {
+			expect(() =>
+				createPreferences({
+					// @ts-expect-error — testing runtime rejection of non-string element
+					lookingFor: { ethnicityPreference: ['asian', 42] },
+				}),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('accepts religionRequired as null', () => {
+			let result = createPreferences({ lookingFor: { religionRequired: null } })
+			expect(result.lookingFor?.religionRequired).toBeNull()
+		})
+
+		test('accepts wantsChildren as null', () => {
+			let result = createPreferences({ lookingFor: { wantsChildren: null } })
+			expect(result.lookingFor?.wantsChildren).toBeNull()
+		})
+	})
+
+	describe('dealBreakers invariants', () => {
+		test('accepts an empty dealBreakers array', () => {
+			let result = createPreferences({ dealBreakers: [] })
+			expect(result.dealBreakers).toEqual([])
+		})
+
+		test('accepts all five valid deal breaker literals', () => {
+			let result = createPreferences({
+				dealBreakers: ['isDivorced', 'hasChildren', 'hasTattoos', 'hasPiercings', 'isSmoker'],
+			})
+			expect(result.dealBreakers).toHaveLength(5)
+		})
+
+		test('throws InvalidPreferencesError when dealBreakers contains an unknown literal', () => {
+			expect(() =>
+				// @ts-expect-error — testing runtime rejection of invalid literal
+				createPreferences({ dealBreakers: ['isSmoker', 'bogus'] }),
+			).toThrow(InvalidPreferencesError)
+		})
+
+		test('throws InvalidPreferencesError when dealBreakers contains duplicates', () => {
+			expect(() =>
+				createPreferences({ dealBreakers: ['isSmoker', 'isSmoker'] }),
+			).toThrow(InvalidPreferencesError)
+		})
+	})
+
+	describe('error shape', () => {
+		test('InvalidPreferencesError extends DomainError', () => {
+			let err: unknown = null
+			try {
+				createPreferences({ aboutMe: { height: -1 } })
+			} catch (e) {
+				err = e
+			}
+			expect(err).toBeInstanceOf(InvalidPreferencesError)
+			expect(err).toBeInstanceOf(DomainError)
+		})
+
+		test('InvalidPreferencesError has a stable code string', () => {
+			let err: unknown = null
+			try {
+				createPreferences({ aboutMe: { height: -1 } })
+			} catch (e) {
+				err = e
+			}
+			expect(err).toBeInstanceOf(InvalidPreferencesError)
+			if (err instanceof InvalidPreferencesError) {
+				expect(typeof err.code).toBe('string')
+				expect(err.code.length).toBeGreaterThan(0)
+			}
+		})
+	})
+})

--- a/packages/shared/tests/domain/validators.test.ts
+++ b/packages/shared/tests/domain/validators.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from 'bun:test'
+import { DomainError } from '../../src/domain/errors'
+import { requireNonEmptyString, assertValidDate } from '../../src/domain/validators'
+
+class TestError extends DomainError {
+	constructor(code: string, message: string) {
+		super(code, message)
+		this.name = 'TestError'
+	}
+}
+
+describe('requireNonEmptyString', () => {
+	test('returns the trimmed value when valid', () => {
+		expect(requireNonEmptyString('  hello  ', 'field', 'CODE', TestError)).toBe('hello')
+	})
+
+	test('returns the original when already trimmed', () => {
+		expect(requireNonEmptyString('id-1', 'field', 'CODE', TestError)).toBe('id-1')
+	})
+
+	test('throws the provided error class on empty string', () => {
+		expect(() => requireNonEmptyString('', 'field', 'CODE', TestError)).toThrow(TestError)
+	})
+
+	test('throws on whitespace-only string', () => {
+		expect(() => requireNonEmptyString('   ', 'field', 'CODE', TestError)).toThrow(TestError)
+	})
+
+	test('throws on non-string value', () => {
+		expect(() => requireNonEmptyString(42, 'field', 'CODE', TestError)).toThrow(TestError)
+	})
+
+	test('thrown error carries the provided code', () => {
+		let err: unknown = null
+		try {
+			requireNonEmptyString('', 'field', 'CODE_X', TestError)
+		} catch (e) {
+			err = e
+		}
+		expect(err).toBeInstanceOf(TestError)
+		if (err instanceof TestError) {
+			expect(err.code).toBe('CODE_X')
+		}
+	})
+})
+
+describe('assertValidDate', () => {
+	test('does not throw for a valid Date', () => {
+		expect(() => assertValidDate(new Date('2026-01-01'), 'field', 'CODE', TestError)).not.toThrow()
+	})
+
+	test('throws the provided error class for an Invalid Date', () => {
+		expect(() => assertValidDate(new Date('not-a-date'), 'field', 'CODE', TestError)).toThrow(
+			TestError,
+		)
+	})
+
+	test('throws for non-Date values', () => {
+		expect(() => assertValidDate('2026-01-01', 'field', 'CODE', TestError)).toThrow(TestError)
+		expect(() => assertValidDate(null, 'field', 'CODE', TestError)).toThrow(TestError)
+		expect(() => assertValidDate(undefined, 'field', 'CODE', TestError)).toThrow(TestError)
+	})
+
+	test('thrown error carries the provided code', () => {
+		let err: unknown = null
+		try {
+			assertValidDate('bad', 'field', 'CODE_Y', TestError)
+		} catch (e) {
+			err = e
+		}
+		expect(err).toBeInstanceOf(TestError)
+		if (err instanceof TestError) {
+			expect(err.code).toBe('CODE_Y')
+		}
+	})
+
+	test('narrows value to Date after assertion', () => {
+		let raw: unknown = new Date('2026-01-01')
+		assertValidDate(raw, 'field', 'CODE', TestError)
+		expect(raw.getTime()).toBeGreaterThan(0)
+	})
+})

--- a/packages/shared/tests/index.test.ts
+++ b/packages/shared/tests/index.test.ts
@@ -1,5 +1,18 @@
 import { describe, test, expect } from 'bun:test'
-import { prompts, getPrompt, MATCHMAKER_INTERVIEW_TEXT } from '../src/index'
+import {
+	prompts,
+	getPrompt,
+	MATCHMAKER_INTERVIEW_TEXT,
+	createPreferences,
+	createPerson,
+	createIntroduction,
+	createMatchDecision,
+	DomainError,
+	InvalidPreferencesError,
+	InvalidPersonError,
+	InvalidIntroductionError,
+	InvalidMatchDecisionError,
+} from '../src/index'
 
 describe('@matchmaker/shared barrel exports', () => {
 	test('exports prompts array', () => {
@@ -13,5 +26,22 @@ describe('@matchmaker/shared barrel exports', () => {
 	test('exports MATCHMAKER_INTERVIEW_TEXT string', () => {
 		expect(typeof MATCHMAKER_INTERVIEW_TEXT).toBe('string')
 		expect(MATCHMAKER_INTERVIEW_TEXT.length).toBeGreaterThan(0)
+	})
+})
+
+describe('domain barrel', () => {
+	test('re-exports createPreferences, createPerson, createIntroduction, createMatchDecision as functions', () => {
+		expect(typeof createPreferences).toBe('function')
+		expect(typeof createPerson).toBe('function')
+		expect(typeof createIntroduction).toBe('function')
+		expect(typeof createMatchDecision).toBe('function')
+	})
+
+	test('re-exports DomainError and all Invalid*Error classes', () => {
+		expect(typeof DomainError).toBe('function')
+		expect(typeof InvalidPreferencesError).toBe('function')
+		expect(typeof InvalidPersonError).toBe('function')
+		expect(typeof InvalidIntroductionError).toBe('function')
+		expect(typeof InvalidMatchDecisionError).toBe('function')
 	})
 })


### PR DESCRIPTION
## Summary

First step of the Clean Architecture migration epic (#60). Introduces framework-free domain entities in `packages/shared/src/domain/` with factory functions that enforce invariants and return frozen values.

- `Preferences` value object (aboutMe, lookingFor, dealBreakers)
- `Person` entity
- `Introduction` entity
- `MatchDecision` entity
- `DomainError` base with one typed `Invalid*Error` subclass per entity

Closes #51.

## Design notes

- **No framework imports** under `src/domain/` — no Zod, Supabase, or Hono. Adapter layer (later epic children) maps DB rows and HTTP shapes into these types.
- **camelCase + `Date`** — domain uses camelCase field names and real `Date` instances; snake_case / ISO string mapping lives at the boundary.
- **Nullability**: nullable DB columns map to `T | null`. Factory inputs accept `undefined` for omitted optionals and normalize to `null`.
- **IDs**: validated as "non-empty trimmed string" only. UUID format is an adapter concern.
- **Immutability**: every entity field is `readonly`; factories return `Object.freeze`-ed values (deep-frozen for `Preferences`).
- **Error reporting**: factories throw a typed `Invalid*Error` subclass of `DomainError`, each carrying a stable `code` string adapters can map.

## New constraint: `age >= 18` on Person

The backend's Zod schema today accepts `z.number().int().positive()` (so 1–17 are valid). The new `createPerson` factory tightens this to integer ≥ 18 when `age` is provided.

This PR does **not** wire the domain into backend code, so existing rows with `age < 18` are harmless. Before a later epic child calls `createPerson` on read paths, we should:

1. Audit existing data: `SELECT count(*) FROM public.people WHERE age < 18;`
2. Decide whether to reject (data fix) or loosen the domain invariant.
3. Tighten `backend/src/schemas/people.ts` with `.min(18)` in the same PR that wires domain into writes so HTTP and domain agree.

## `Person.preferences` stays opaque

`Person.preferences` is typed as `Readonly<Record<string, unknown>> | null` in this PR, not `Preferences | null`. The `people.preferences` column is `jsonb` and existing rows may not match the new `Preferences` shape. A later issue will tighten the type after a data audit.

## TDD trail

Commits alternate red (failing tests) and green (implementation) for each entity so a reviewer can check out any red commit and watch the new tests fail. Ten commits total.

## Test plan

- [x] `cd packages/shared && bun test` — 95 pass, 0 fail
- [x] `bun run test` at repo root — shared 95, backend 211, mcp-server 127, gateway 8 — all green
- [x] `bunx tsc --noEmit` in `packages/shared` — no new errors from the domain files (the pre-existing `tests/prompts.test.ts` MCP SDK discriminated-union errors are unchanged)
- [x] No new dependencies added to `packages/shared/package.json`
- [x] Grep confirms: zero imports of `zod`, `@supabase/supabase-js`, or `hono` anywhere under `src/domain/`

## Out of scope

- Wiring any of these entities into `backend/`, `mcp-server/`, `gateway/`, or `mobile/` (later epic children: #52–#59)
- Tightening `Person.preferences` to the `Preferences` value object
- Any backend schema or route changes