### PR TITLE
fix(scripts): exclude cross-workspace files from coverage-diff totals

### DIFF
--- a/scripts/coverage-diff.test.ts
+++ b/scripts/coverage-diff.test.ts
@@ -56,6 +56,51 @@ end_of_record
       "src/foo.ts": { linesFound: 5, linesHit: 0 },
     });
   });
+
+  it("excludes records whose path escapes the package root", () => {
+    const lcov = `SF:src/local.ts
+LF:10
+LH:8
+end_of_record
+SF:../packages/shared/src/domain/person.ts
+LF:20
+LH:20
+end_of_record
+`;
+    expect(parseLcov(lcov)).toEqual({
+      "src/local.ts": { linesFound: 10, linesHit: 8 },
+    });
+  });
+
+  it("does not contaminate a later local record with an excluded record's counts", () => {
+    const lcov = `SF:../packages/shared/src/domain/person.ts
+LF:100
+LH:100
+end_of_record
+SF:src/local.ts
+LF:10
+LH:3
+end_of_record
+`;
+    expect(parseLcov(lcov)).toEqual({
+      "src/local.ts": { linesFound: 10, linesHit: 3 },
+    });
+  });
+
+  it("applies the cross-workspace exclusion after stripPrefix", () => {
+    const lcov = `SF:/checkout/__base/backend/src/local.ts
+LF:10
+LH:8
+end_of_record
+SF:/checkout/__base/backend/../packages/shared/src/foo.ts
+LF:20
+LH:20
+end_of_record
+`;
+    expect(parseLcov(lcov, "/checkout/__base/backend/")).toEqual({
+      "src/local.ts": { linesFound: 10, linesHit: 8 },
+    });
+  });
 });
 
 describe("generateReport", () => {
@@ -127,6 +172,38 @@ describe("generateReport", () => {
     expect(report).toContain("New package");
     expect(report).toContain("90.0%");
     expect(report).not.toContain("+/-");
+  });
+
+  it("ignores cross-workspace files when computing consumer totals", () => {
+    const baseLcov = `SF:src/local.ts
+LF:10
+LH:8
+end_of_record
+SF:../packages/shared/src/domain/person.ts
+LF:100
+LH:5
+end_of_record
+`;
+    const headLcov = `SF:src/local.ts
+LF:10
+LH:8
+end_of_record
+SF:../packages/shared/src/domain/person.ts
+LF:100
+LH:5
+end_of_record
+`;
+
+    const report = generateReport([
+      {
+        name: "backend",
+        base: parseLcov(baseLcov),
+        head: parseLcov(headLcov),
+      },
+    ]);
+
+    expect(report).toContain("80.0%");
+    expect(report).not.toContain("shared/src/domain/person.ts");
   });
 
   it("only shows changed files in the details section", () => {

--- a/scripts/coverage-diff.ts
+++ b/scripts/coverage-diff.ts
@@ -29,7 +29,9 @@ export function parseLcov(content: string, stripPrefix?: string): CoverageMap {
       if (stripPrefix && filePath.startsWith(stripPrefix)) {
         filePath = filePath.slice(stripPrefix.length);
       }
-      currentFile = filePath;
+      // Paths escaping the package root belong to a sibling workspace;
+      // drop the record so it doesn't inflate this package's totals.
+      currentFile = filePath.startsWith("../") ? null : filePath;
       linesFound = 0;
       linesHit = 0;
     } else if (trimmed.startsWith("LF:")) {


### PR DESCRIPTION
## Summary
- `parseLcov` now drops `SF:` records whose path escapes the package root (`../`), so files imported from sibling workspaces no longer inflate the consumer package's denominator in the coverage-diff report
- Adds 4 tests covering the filter — 3 unit cases on `parseLcov` (basic exclusion, no contamination of later records, ordering with `stripPrefix`) and 1 integration case through `generateReport`

## Why
`bun test --coverage` emits lcov records for every file loaded at runtime, including files re-exported from `@matchmaker/shared`. `scripts/coverage-diff.ts` summed all of them into each package's totals, so a PR touching only `packages/shared` would show large phantom drops in `backend` and `mcp-server` — #61 showed -9.1% and -16.0% respectively for packages the PR never touched. Those same files are already reported (correctly, at 100%) under the `shared` row.

Closes #62.

## Test plan
- [x] `bun test scripts/coverage-diff.test.ts` — 16 pass, 0 fail
- [ ] PR's own coverage-diff comment shows 0% change for backend / mcp-server / shared / gateway, with only the `scripts` row reflecting the new test lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)