### PR TITLE
refactor(backend): decouple matchFinder from SupabaseClient (#56)

### DIFF
--- a/backend/src/adapters/supabase/supabase-person-repository.ts
+++ b/backend/src/adapters/supabase/supabase-person-repository.ts
@@ -104,6 +104,16 @@ export class SupabasePersonRepository implements IPersonRepository {
 		return rows.map(parsePersonRow)
 	}
 
+	async findAllActive(): Promise<readonly Person[]> {
+		let { data, error } = await this.client
+			.from('people')
+			.select('*')
+			.eq('active', true)
+		if (error) throw translateSupabaseError(error)
+		let rows: unknown[] = data ?? []
+		return rows.map(parsePersonRow)
+	}
+
 	async create(person: Person): Promise<Person> {
 		let { data, error } = await this.client
 			.from('people')

--- a/backend/src/routes/matches.ts
+++ b/backend/src/routes/matches.ts
@@ -1,5 +1,9 @@
 import { Hono } from 'hono'
 import type { SupabaseClient } from '../lib/supabase'
+import {
+	SupabaseMatchDecisionRepository,
+	SupabasePersonRepository,
+} from '../adapters/supabase'
 import { matchFinder } from '../services/matchFinder'
 
 type Variables = {
@@ -32,7 +36,9 @@ export let createMatchesRoutes = (
 		}
 
 		try {
-			let matches = await matchFinder(personId, userId, supabaseClient)
+			let personRepo = new SupabasePersonRepository(supabaseClient)
+			let matchDecisionRepo = new SupabaseMatchDecisionRepository(supabaseClient)
+			let matches = await matchFinder(personId, userId, personRepo, matchDecisionRepo)
 			return c.json(matches, 200)
 		} catch (error) {
 			let message = error instanceof Error ? error.message : 'Failed to find matches'

--- a/backend/src/routes/mcp.ts
+++ b/backend/src/routes/mcp.ts
@@ -13,6 +13,10 @@ import {
 import type { SupabaseClient } from '../lib/supabase'
 import { prompts, getPrompt } from '@matchmaker/shared'
 import { parsePreferences } from '../schemas/preferences'
+import {
+	SupabaseMatchDecisionRepository,
+	SupabasePersonRepository,
+} from '../adapters/supabase'
 import { matchFinder } from '../services/matchFinder'
 import { createIntroduction } from '../services/introductions'
 
@@ -566,7 +570,14 @@ export let createMcpRoutes = (supabaseClient: SupabaseClient) => {
 					if (personError) throw new Error(personError.message)
 					if (!person) throw new Error('Person not found')
 
-					let matches = await matchFinder(args.person_id, userId, supabaseClient)
+					let personRepo = new SupabasePersonRepository(supabaseClient)
+					let matchDecisionRepo = new SupabaseMatchDecisionRepository(supabaseClient)
+					let matches = await matchFinder(
+						args.person_id,
+						userId,
+						personRepo,
+						matchDecisionRepo,
+					)
 					return {
 						content: [{ type: 'text', text: JSON.stringify(matches, null, 2) }],
 					}

--- a/backend/src/services/matchFinder.ts
+++ b/backend/src/services/matchFinder.ts
@@ -1,12 +1,44 @@
-import type { IMatchDecisionRepository, IPersonRepository } from '@matchmaker/shared'
+import type {
+	IMatchDecisionRepository,
+	IPersonRepository,
+	Person,
+} from '@matchmaker/shared'
+import { findMatches } from './matchingAlgorithm'
 import type { MatchResponse } from '../schemas/matches'
+import type { PersonResponse } from '../schemas/people'
 
-// STUB — real implementation lands in the next commit (TDD red → green).
+let toPersonResponse = (p: Person): PersonResponse => ({
+	id: p.id,
+	matchmaker_id: p.matchmakerId,
+	name: p.name,
+	age: p.age,
+	location: p.location,
+	gender: p.gender,
+	preferences: p.preferences === null ? null : { ...p.preferences },
+	personality: p.personality === null ? null : { ...p.personality },
+	notes: p.notes,
+	active: p.active,
+	created_at: p.createdAt.toISOString(),
+	updated_at: p.updatedAt.toISOString(),
+})
+
+// Orchestrates match finding by fetching all active people (cross-matchmaker pool),
+// excluding candidates the matchmaker has already declined, then running the algorithm.
 export let matchFinder = async (
-	_personId: string,
-	_matchmakerId: string,
-	_personRepo: IPersonRepository,
-	_matchDecisionRepo: IMatchDecisionRepository,
+	personId: string,
+	matchmakerId: string,
+	personRepo: IPersonRepository,
+	matchDecisionRepo: IMatchDecisionRepository,
 ): Promise<MatchResponse[]> => {
-	throw new Error('matchFinder: not implemented')
+	let allPeople = await personRepo.findAllActive()
+	let decisions = await matchDecisionRepo.findByPerson(personId)
+
+	let excludeIds = new Set<string>(
+		decisions
+			.filter(d => d.decision === 'declined' && d.matchmakerId === matchmakerId)
+			.map(d => d.candidateId),
+	)
+
+	let eligible = allPeople.filter(p => !excludeIds.has(p.id)).map(toPersonResponse)
+	return findMatches(personId, eligible)
 }

--- a/backend/src/services/matchFinder.ts
+++ b/backend/src/services/matchFinder.ts
@@ -1,42 +1,12 @@
-import type { SupabaseClient } from '../lib/supabase'
-import { findMatches } from './matchingAlgorithm'
+import type { IMatchDecisionRepository, IPersonRepository } from '@matchmaker/shared'
 import type { MatchResponse } from '../schemas/matches'
 
-// Orchestrates match finding by fetching all active people (cross-matchmaker pool),
-// excluding candidates the matchmaker has already reviewed, then running the algorithm.
+// STUB — real implementation lands in the next commit (TDD red → green).
 export let matchFinder = async (
-	personId: string,
-	matchmakerId: string,
-	supabaseClient: SupabaseClient
+	_personId: string,
+	_matchmakerId: string,
+	_personRepo: IPersonRepository,
+	_matchDecisionRepo: IMatchDecisionRepository,
 ): Promise<MatchResponse[]> => {
-	// Fetch ALL active people — seed profiles and all matchmakers' clients
-	let { data: allPeople, error: peopleError } = await supabaseClient
-		.from('people')
-		.select('*')
-		.eq('active', true)
-
-	if (peopleError) {
-		throw new Error(peopleError.message)
-	}
-
-	// Fetch declined decisions to build the exclusion set
-	let { data: decisions, error: decisionsError } = await supabaseClient
-		.from('match_decisions')
-		.select('candidate_id')
-		.eq('person_id', personId)
-		.eq('matchmaker_id', matchmakerId)
-		.eq('decision', 'declined')
-
-	if (decisionsError) {
-		throw new Error(decisionsError.message)
-	}
-
-	let excludeIds = new Set<string>(
-		(decisions || []).map((d: { candidate_id: string }) => d.candidate_id)
-	)
-
-	// Exclude declined candidates (accepted candidates remain visible)
-	let eligiblePeople = (allPeople || []).filter(p => !excludeIds.has(p.id))
-
-	return findMatches(personId, eligiblePeople)
+	throw new Error('matchFinder: not implemented')
 }

--- a/backend/src/services/matchFinder.ts
+++ b/backend/src/services/matchFinder.ts
@@ -7,6 +7,10 @@ import { findMatches } from './matchingAlgorithm'
 import type { MatchResponse } from '../schemas/matches'
 import type { PersonResponse } from '../schemas/people'
 
+// TODO(#71): remove once matchingAlgorithm accepts domain Person entities.
+// This mapper only exists because findMatches still consumes the snake_case
+// PersonResponse schema shape — a layer leak between the use case and the
+// otherwise framework-free algorithmic core.
 let toPersonResponse = (p: Person): PersonResponse => ({
 	id: p.id,
 	matchmaker_id: p.matchmakerId,

--- a/backend/tests/adapters/supabase/supabase-person-repository.test.ts
+++ b/backend/tests/adapters/supabase/supabase-person-repository.test.ts
@@ -113,6 +113,43 @@ describe('SupabasePersonRepository.findByMatchmakerId', () => {
 	})
 })
 
+describe('SupabasePersonRepository.findAllActive', () => {
+	test('returns empty array when no rows match', async () => {
+		let { client } = createFake({ data: [], error: null })
+		let repo = new SupabasePersonRepository(client)
+
+		let result = await repo.findAllActive()
+
+		expect(result).toEqual([])
+	})
+
+	test('queries people filtered by active=true and returns frozen Person entities', async () => {
+		let rowB = { ...validPersonRow, id: '33333333-3333-3333-3333-333333333333', name: 'Grace Hopper' }
+		let { client, calls } = createFake({ data: [validPersonRow, rowB], error: null })
+		let repo = new SupabasePersonRepository(client)
+
+		let result = await repo.findAllActive()
+
+		expect(result).toHaveLength(2)
+		expect(result[0]?.name).toBe('Ada Lovelace')
+		expect(result[1]?.name).toBe('Grace Hopper')
+		expect(Object.isFrozen(result[0])).toBe(true)
+		expect(calls.find(c => c.method === 'from')?.args[0]).toBe('people')
+		let eqCall = calls.find(c => c.method === 'eq')
+		expect(eqCall?.args).toEqual(['active', true])
+	})
+
+	test('throws RepositoryError on supabase error', async () => {
+		let { client } = createFake({
+			data: null,
+			error: { code: 'XX000', message: 'db down', details: '', hint: '', name: 'PostgrestError' },
+		})
+		let repo = new SupabasePersonRepository(client)
+
+		await expect(repo.findAllActive()).rejects.toBeInstanceOf(RepositoryError)
+	})
+})
+
 let buildPersonFromValidRow = () =>
 	createPerson({
 		id: validPersonRow.id,

--- a/backend/tests/fakes/in-memory-repositories.ts
+++ b/backend/tests/fakes/in-memory-repositories.ts
@@ -1,0 +1,92 @@
+import {
+	PersonNotFoundError,
+	RepositoryConflictError,
+	type IMatchDecisionRepository,
+	type IPersonRepository,
+	type MatchDecision,
+	type Person,
+	type PersonUpdate,
+} from '@matchmaker/shared'
+
+export class InMemoryPersonRepository implements IPersonRepository {
+	private people: Person[]
+
+	constructor(seed: readonly Person[] = []) {
+		this.people = [...seed]
+	}
+
+	async findById(id: string): Promise<Person | null> {
+		return this.people.find(p => p.id === id) ?? null
+	}
+
+	async findByMatchmakerId(matchmakerId: string): Promise<readonly Person[]> {
+		return this.people.filter(p => p.matchmakerId === matchmakerId)
+	}
+
+	async findAllActive(): Promise<readonly Person[]> {
+		return this.people.filter(p => p.active)
+	}
+
+	async create(person: Person): Promise<Person> {
+		if (this.people.some(p => p.id === person.id)) {
+			throw new RepositoryConflictError(`Person already exists: ${person.id}`)
+		}
+		this.people.push(person)
+		return person
+	}
+
+	async update(id: string, patch: PersonUpdate): Promise<Person> {
+		let index = this.people.findIndex(p => p.id === id)
+		if (index === -1) throw new PersonNotFoundError(id)
+		let current = this.people[index]!
+		let updated: Person = Object.freeze({
+			...current,
+			...patch,
+			updatedAt: new Date(),
+		})
+		this.people[index] = updated
+		return updated
+	}
+
+	async delete(id: string): Promise<void> {
+		let index = this.people.findIndex(p => p.id === id)
+		if (index === -1) throw new PersonNotFoundError(id)
+		this.people.splice(index, 1)
+	}
+}
+
+export class InMemoryMatchDecisionRepository implements IMatchDecisionRepository {
+	private decisions: MatchDecision[]
+
+	constructor(seed: readonly MatchDecision[] = []) {
+		this.decisions = [...seed]
+	}
+
+	async findByPerson(personId: string): Promise<readonly MatchDecision[]> {
+		return this.decisions.filter(d => d.personId === personId)
+	}
+
+	async findByCandidatePair(
+		personId: string,
+		candidateId: string,
+	): Promise<MatchDecision | null> {
+		return (
+			this.decisions.find(
+				d => d.personId === personId && d.candidateId === candidateId,
+			) ?? null
+		)
+	}
+
+	async create(decision: MatchDecision): Promise<MatchDecision> {
+		let conflict = this.decisions.some(
+			d => d.personId === decision.personId && d.candidateId === decision.candidateId,
+		)
+		if (conflict) {
+			throw new RepositoryConflictError(
+				`Decision already exists for (${decision.personId}, ${decision.candidateId})`,
+			)
+		}
+		this.decisions.push(decision)
+		return decision
+	}
+}

--- a/backend/tests/routes/matches.test.ts
+++ b/backend/tests/routes/matches.test.ts
@@ -171,19 +171,24 @@ describe('GET /api/matches/:personId', () => {
 			},
 		]
 
+		let declinedDecisionRow = {
+			id: '950e8400-e29b-41d4-a716-446655440009',
+			matchmaker_id: mockUserId,
+			person_id: mockPersonId,
+			candidate_id: declinedCandidateId,
+			decision: 'declined',
+			decline_reason: 'not a fit',
+			created_at: new Date().toISOString(),
+		}
+
 		let mockClient = createMockSupabaseClient({
 			from: mock((table: string) => {
 				if (table === 'match_decisions') {
 					return {
 						select: mock((_columns: string) => ({
 							eq: mock((_col: string, _val: unknown) => ({
-								eq: mock((_col2: string, _val2: unknown) => ({
-									eq: mock((_col3: string, _val3: unknown) => ({
-										// Only declined decisions are returned by the query
-										data: [{ candidate_id: declinedCandidateId }],
-										error: null,
-									})),
-								})),
+								data: [declinedDecisionRow],
+								error: null,
 							})),
 						})),
 					}

--- a/backend/tests/services/matchFinder.test.ts
+++ b/backend/tests/services/matchFinder.test.ts
@@ -1,0 +1,162 @@
+import { describe, test, expect } from 'bun:test'
+import { createMatchDecision, createPerson } from '@matchmaker/shared'
+import { matchFinder } from '../../src/services/matchFinder'
+import {
+	InMemoryMatchDecisionRepository,
+	InMemoryPersonRepository,
+} from '../fakes/in-memory-repositories'
+
+let now = new Date('2026-01-01T00:00:00.000Z')
+
+let buildPerson = (overrides: {
+	id: string
+	matchmakerId?: string | null
+	active?: boolean
+}) =>
+	createPerson({
+		id: overrides.id,
+		matchmakerId: overrides.matchmakerId ?? 'mm-1',
+		name: `Person ${overrides.id}`,
+		age: 30,
+		location: null,
+		gender: null,
+		preferences: null,
+		personality: null,
+		notes: null,
+		active: overrides.active ?? true,
+		createdAt: now,
+		updatedAt: now,
+	})
+
+let buildDecision = (overrides: {
+	id: string
+	matchmakerId: string
+	personId: string
+	candidateId: string
+	decision: 'accepted' | 'declined'
+}) =>
+	createMatchDecision({
+		id: overrides.id,
+		matchmakerId: overrides.matchmakerId,
+		personId: overrides.personId,
+		candidateId: overrides.candidateId,
+		decision: overrides.decision,
+		declineReason: overrides.decision === 'declined' ? 'not a fit' : null,
+		createdAt: now,
+	})
+
+describe('matchFinder', () => {
+	test('returns algorithm output over the active-people pool', async () => {
+		// Arrange
+		let subject = buildPerson({ id: 'subject' })
+		let candidate = buildPerson({ id: 'cand-1' })
+		let personRepo = new InMemoryPersonRepository([subject, candidate])
+		let matchDecisionRepo = new InMemoryMatchDecisionRepository()
+
+		// Act
+		let matches = await matchFinder('subject', 'mm-1', personRepo, matchDecisionRepo)
+
+		// Assert
+		expect(matches).toHaveLength(1)
+		expect(matches[0]?.person.id).toBe('cand-1')
+	})
+
+	test('excludes declined candidates for this matchmaker', async () => {
+		// Arrange
+		let subject = buildPerson({ id: 'subject' })
+		let candA = buildPerson({ id: 'cand-A' })
+		let candB = buildPerson({ id: 'cand-B' })
+		let personRepo = new InMemoryPersonRepository([subject, candA, candB])
+		let matchDecisionRepo = new InMemoryMatchDecisionRepository([
+			buildDecision({
+				id: 'd-1',
+				matchmakerId: 'mm-1',
+				personId: 'subject',
+				candidateId: 'cand-A',
+				decision: 'declined',
+			}),
+		])
+
+		// Act
+		let matches = await matchFinder('subject', 'mm-1', personRepo, matchDecisionRepo)
+
+		// Assert
+		let matchedIds = matches.map(m => m.person.id)
+		expect(matchedIds).not.toContain('cand-A')
+		expect(matchedIds).toContain('cand-B')
+	})
+
+	test('still includes accepted candidates in results', async () => {
+		// Arrange
+		let subject = buildPerson({ id: 'subject' })
+		let candA = buildPerson({ id: 'cand-A' })
+		let personRepo = new InMemoryPersonRepository([subject, candA])
+		let matchDecisionRepo = new InMemoryMatchDecisionRepository([
+			buildDecision({
+				id: 'd-1',
+				matchmakerId: 'mm-1',
+				personId: 'subject',
+				candidateId: 'cand-A',
+				decision: 'accepted',
+			}),
+		])
+
+		// Act
+		let matches = await matchFinder('subject', 'mm-1', personRepo, matchDecisionRepo)
+
+		// Assert
+		expect(matches.map(m => m.person.id)).toContain('cand-A')
+	})
+
+	test('ignores declines recorded by a different matchmaker', async () => {
+		// Arrange
+		let subject = buildPerson({ id: 'subject' })
+		let candA = buildPerson({ id: 'cand-A' })
+		let personRepo = new InMemoryPersonRepository([subject, candA])
+		let matchDecisionRepo = new InMemoryMatchDecisionRepository([
+			buildDecision({
+				id: 'd-1',
+				matchmakerId: 'mm-2',
+				personId: 'subject',
+				candidateId: 'cand-A',
+				decision: 'declined',
+			}),
+		])
+
+		// Act
+		let matches = await matchFinder('subject', 'mm-1', personRepo, matchDecisionRepo)
+
+		// Assert
+		expect(matches.map(m => m.person.id)).toContain('cand-A')
+	})
+
+	test('skips inactive people', async () => {
+		// Arrange
+		let subject = buildPerson({ id: 'subject' })
+		let active = buildPerson({ id: 'cand-active', active: true })
+		let inactive = buildPerson({ id: 'cand-inactive', active: false })
+		let personRepo = new InMemoryPersonRepository([subject, active, inactive])
+		let matchDecisionRepo = new InMemoryMatchDecisionRepository()
+
+		// Act
+		let matches = await matchFinder('subject', 'mm-1', personRepo, matchDecisionRepo)
+
+		// Assert
+		let matchedIds = matches.map(m => m.person.id)
+		expect(matchedIds).toContain('cand-active')
+		expect(matchedIds).not.toContain('cand-inactive')
+	})
+
+	test('returns empty array when no candidates exist', async () => {
+		// Arrange
+		let subject = buildPerson({ id: 'subject' })
+		let personRepo = new InMemoryPersonRepository([subject])
+		let matchDecisionRepo = new InMemoryMatchDecisionRepository()
+
+		// Act
+		let matches = await matchFinder('subject', 'mm-1', personRepo, matchDecisionRepo)
+
+		// Assert
+		expect(matches).toEqual([])
+	})
+})

--- a/packages/shared/src/repositories/person-repository.ts
+++ b/packages/shared/src/repositories/person-repository.ts
@@ -8,6 +8,8 @@ export type PersonUpdate = Partial<
 export interface IPersonRepository {
 	findById(id: string): Promise<Person | null>
 	findByMatchmakerId(matchmakerId: string): Promise<readonly Person[]>
+	/** Returns every active person across all matchmakers — the cross-matchmaker candidate pool. */
+	findAllActive(): Promise<readonly Person[]>
 	create(person: Person): Promise<Person>
 	/** Throws PersonNotFoundError when no row matches `id`. */
 	update(id: string, patch: PersonUpdate): Promise<Person>


### PR DESCRIPTION
## Summary

Resolves #56. Replaces `matchFinder`'s `SupabaseClient` dependency with `IPersonRepository` + `IMatchDecisionRepository`, so the use case can be unit-tested with in-memory fakes and no Supabase mocking.

- `matchFinder.ts` — new signature `(personId, matchmakerId, personRepo, matchDecisionRepo)`; declined-exclusion rule expressed in-memory against domain entities; zero `@supabase/supabase-js` imports
- `IPersonRepository` gains `findAllActive()` for the cross-matchmaker candidate pool; implemented in `SupabasePersonRepository` with supporting adapter tests
- New `backend/tests/fakes/in-memory-repositories.ts` — `InMemoryPersonRepository`, `InMemoryMatchDecisionRepository`
- New `backend/tests/services/matchFinder.test.ts` — six AAA unit tests using only the in-memory fakes
- `routes/matches.ts` and the `find_matches` MCP tool in `routes/mcp.ts` construct repository instances inline and inject them (composition-root helper intentionally deferred to a later use-case-layer issue)
- Existing `tests/routes/matches.test.ts` mock updated for the new `findByPerson` query shape

Commits walk the TDD cycle: interface → adapter impl → tests+stub (RED) → use-case impl (GREEN) → route wiring.

## Acceptance (issue #56)

- [x] `matchFinder.ts` has no import of `@supabase/supabase-js`
- [x] Its test file runs with an in-memory fake repository (no `tests/mocks/supabase.ts` needed)
- [x] Call sites updated to pass repository instances (simple composition root)
- [x] Existing behavior unchanged — integration tests still pass

## Test plan

- [x] `npm test` — shared 153 ✓ · backend 258 ✓ · mcp-server 127 ✓ · gateway 28 ✓
- [x] `grep @supabase/supabase-js backend/src/services/matchFinder.ts` — empty
- [x] `grep tests/mocks/supabase backend/tests/services/matchFinder.test.ts` — empty
- [ ] Smoke test `GET /api/matches/:personId` against a running dev server (optional — behavior is covered by the integration test in `tests/routes/matches.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)