### PR TITLE
refactor(backend): decouple introductions service from Supabase (#57)

### DIFF
--- a/backend/src/routes/introductions.ts
+++ b/backend/src/routes/introductions.ts
@@ -1,12 +1,29 @@
 import { Hono } from 'hono'
 import { zValidator } from '@hono/zod-validator'
+import type { Introduction } from '@matchmaker/shared'
 import type { SupabaseClient } from '../lib/supabase'
+import {
+	SupabaseIntroductionRepository,
+	SupabasePersonRepository,
+} from '../adapters/supabase'
 import { createIntroductionSchema, updateIntroductionSchema } from '../schemas/introductions'
 import { createIntroduction } from '../services/introductions'
 
 type Variables = {
 	userId: string
 }
+
+let introductionToResponse = (intro: Introduction) => ({
+	id: intro.id,
+	matchmaker_a_id: intro.matchmakerAId,
+	matchmaker_b_id: intro.matchmakerBId,
+	person_a_id: intro.personAId,
+	person_b_id: intro.personBId,
+	status: intro.status,
+	notes: intro.notes,
+	created_at: intro.createdAt.toISOString(),
+	updated_at: intro.updatedAt.toISOString(),
+})
 
 export let createIntroductionsRoutes = (
 	supabaseClient: SupabaseClient
@@ -17,18 +34,29 @@ export let createIntroductionsRoutes = (
 		let userId = c.get('userId')
 		let data = c.req.valid('json')
 
-		let result = await createIntroduction(supabaseClient, {
-			person_a_id: data.person_a_id,
-			person_b_id: data.person_b_id,
-			notes: data.notes,
-			userId,
-		})
+		let personRepo = new SupabasePersonRepository(supabaseClient)
+		let introductionRepo = new SupabaseIntroductionRepository(supabaseClient)
 
-		if (result.error) {
-			return c.json({ error: result.error.message }, result.error.status as 403 | 404 | 500)
+		try {
+			let result = await createIntroduction(personRepo, introductionRepo, {
+				person_a_id: data.person_a_id,
+				person_b_id: data.person_b_id,
+				notes: data.notes,
+				userId,
+			})
+
+			if (result.error) {
+				return c.json(
+					{ error: result.error.message },
+					result.error.status as 403 | 404 | 422 | 500,
+				)
+			}
+
+			return c.json(introductionToResponse(result.data), 201)
+		} catch (err) {
+			let message = err instanceof Error ? err.message : 'Failed to create introduction'
+			return c.json({ error: message }, 500)
 		}
-
-		return c.json(result.data, 201)
 	})
 
 	app.get('/', async c => {

--- a/backend/src/routes/introductions.ts
+++ b/backend/src/routes/introductions.ts
@@ -46,10 +46,7 @@ export let createIntroductionsRoutes = (
 			})
 
 			if (result.error) {
-				return c.json(
-					{ error: result.error.message },
-					result.error.status as 403 | 404 | 422 | 500,
-				)
+				return c.json({ error: result.error.message }, result.error.status)
 			}
 
 			return c.json(introductionToResponse(result.data), 201)

--- a/backend/src/services/introductions.ts
+++ b/backend/src/services/introductions.ts
@@ -13,9 +13,11 @@ type CreateIntroductionParams = {
 	userId: string
 }
 
+type IntroductionErrorStatus = 403 | 404 | 422 | 500
+
 type IntroductionResult =
 	| { data: Introduction; error: null }
-	| { data: null; error: { message: string; status: number } }
+	| { data: null; error: { message: string; status: IntroductionErrorStatus } }
 
 export let createIntroduction = async (
 	personRepo: IPersonRepository,

--- a/backend/src/services/introductions.ts
+++ b/backend/src/services/introductions.ts
@@ -1,4 +1,10 @@
-import type { SupabaseClient } from '../lib/supabase'
+import {
+	AuthorizationService,
+	createIntroduction as buildIntroduction,
+	type IIntroductionRepository,
+	type IPersonRepository,
+	type Introduction,
+} from '@matchmaker/shared'
 
 type CreateIntroductionParams = {
 	person_a_id: string
@@ -8,59 +14,56 @@ type CreateIntroductionParams = {
 }
 
 type IntroductionResult =
-	| { data: Record<string, unknown>; error: null }
+	| { data: Introduction; error: null }
 	| { data: null; error: { message: string; status: number } }
 
 export let createIntroduction = async (
-	supabaseClient: SupabaseClient,
-	params: CreateIntroductionParams
+	personRepo: IPersonRepository,
+	introductionRepo: IIntroductionRepository,
+	params: CreateIntroductionParams,
 ): Promise<IntroductionResult> => {
-	let { person_a_id, person_b_id, notes, userId } = params
-
-	// Look up both people to get their matchmaker IDs
-	let { data: personA, error: personAError } = await supabaseClient
-		.from('people')
-		.select('id, matchmaker_id')
-		.eq('id', person_a_id)
-		.single()
-
-	if (personAError || !personA) {
+	let personA = await personRepo.findById(params.person_a_id)
+	if (!personA) {
 		return { data: null, error: { message: 'Person A not found', status: 404 } }
 	}
 
-	let { data: personB, error: personBError } = await supabaseClient
-		.from('people')
-		.select('id, matchmaker_id')
-		.eq('id', person_b_id)
-		.single()
-
-	if (personBError || !personB) {
+	let personB = await personRepo.findById(params.person_b_id)
+	if (!personB) {
 		return { data: null, error: { message: 'Person B not found', status: 404 } }
 	}
 
-	// Validate the requesting user owns at least one of the people
-	if (personA.matchmaker_id !== userId && personB.matchmaker_id !== userId) {
+	if (!AuthorizationService.canMatchmakerCreateIntroduction(params.userId, personA, personB)) {
 		return {
 			data: null,
-			error: { message: 'You must own at least one person in the introduction', status: 403 },
+			error: {
+				message: 'You must own at least one person in the introduction',
+				status: 403,
+			},
 		}
 	}
 
-	let { data: introduction, error } = await supabaseClient
-		.from('introductions')
-		.insert({
-			person_a_id,
-			person_b_id,
-			notes: notes || null,
-			matchmaker_a_id: personA.matchmaker_id,
-			matchmaker_b_id: personB.matchmaker_id,
-		})
-		.select()
-		.single()
-
-	if (error) {
-		return { data: null, error: { message: error.message, status: 500 } }
+	// Introduction entity requires non-null matchmaker ids on both sides. Authorization above
+	// guarantees at least one side is owned by the requester, but the other side could still
+	// be an unassigned person — reject rather than fabricate a matchmaker id.
+	if (personA.matchmakerId === null || personB.matchmakerId === null) {
+		return {
+			data: null,
+			error: { message: 'Both people must belong to a matchmaker', status: 422 },
+		}
 	}
 
-	return { data: introduction, error: null }
+	let now = new Date()
+	let intro = buildIntroduction({
+		id: crypto.randomUUID(),
+		matchmakerAId: personA.matchmakerId,
+		matchmakerBId: personB.matchmakerId,
+		personAId: personA.id,
+		personBId: personB.id,
+		notes: params.notes ?? null,
+		createdAt: now,
+		updatedAt: now,
+	})
+
+	let saved = await introductionRepo.create(intro)
+	return { data: saved, error: null }
 }

--- a/backend/tests/fakes/in-memory-repositories.ts
+++ b/backend/tests/fakes/in-memory-repositories.ts
@@ -1,8 +1,12 @@
 import {
+	IntroductionNotFoundError,
 	PersonNotFoundError,
 	RepositoryConflictError,
+	type IIntroductionRepository,
 	type IMatchDecisionRepository,
 	type IPersonRepository,
+	type Introduction,
+	type IntroductionUpdate,
 	type MatchDecision,
 	type Person,
 	type PersonUpdate,
@@ -88,5 +92,44 @@ export class InMemoryMatchDecisionRepository implements IMatchDecisionRepository
 		}
 		this.decisions.push(decision)
 		return decision
+	}
+}
+
+export class InMemoryIntroductionRepository implements IIntroductionRepository {
+	private introductions: Introduction[]
+
+	constructor(seed: readonly Introduction[] = []) {
+		this.introductions = [...seed]
+	}
+
+	async findById(id: string): Promise<Introduction | null> {
+		return this.introductions.find(i => i.id === id) ?? null
+	}
+
+	async findByMatchmaker(matchmakerId: string): Promise<readonly Introduction[]> {
+		return this.introductions.filter(
+			i => i.matchmakerAId === matchmakerId || i.matchmakerBId === matchmakerId,
+		)
+	}
+
+	async create(introduction: Introduction): Promise<Introduction> {
+		if (this.introductions.some(i => i.id === introduction.id)) {
+			throw new RepositoryConflictError(`Introduction already exists: ${introduction.id}`)
+		}
+		this.introductions.push(introduction)
+		return introduction
+	}
+
+	async update(id: string, patch: IntroductionUpdate): Promise<Introduction> {
+		let index = this.introductions.findIndex(i => i.id === id)
+		if (index === -1) throw new IntroductionNotFoundError(id)
+		let current = this.introductions[index]!
+		let updated: Introduction = Object.freeze({
+			...current,
+			...patch,
+			updatedAt: new Date(),
+		})
+		this.introductions[index] = updated
+		return updated
 	}
 }

--- a/backend/tests/routes/introductions.test.ts
+++ b/backend/tests/routes/introductions.test.ts
@@ -13,44 +13,86 @@ let otherMatchmakerId = '999e8400-e29b-41d4-a716-446655440099'
 let personAId = '750e8400-e29b-41d4-a716-446655440002'
 let personBId = '850e8400-e29b-41d4-a716-446655440003'
 
+let buildPersonRow = (id: string, matchmakerId: string) => ({
+	id,
+	matchmaker_id: matchmakerId,
+	name: `Person ${id}`,
+	age: 30,
+	location: null,
+	gender: null,
+	preferences: null,
+	personality: null,
+	notes: null,
+	active: true,
+	created_at: new Date().toISOString(),
+	updated_at: new Date().toISOString(),
+})
+
+let buildIntroRow = (overrides: {
+	id: string
+	matchmakerAId: string
+	matchmakerBId: string
+	personAId: string
+	personBId: string
+	notes?: string | null
+}) => ({
+	id: overrides.id,
+	matchmaker_a_id: overrides.matchmakerAId,
+	matchmaker_b_id: overrides.matchmakerBId,
+	person_a_id: overrides.personAId,
+	person_b_id: overrides.personBId,
+	status: 'pending',
+	notes: overrides.notes ?? null,
+	created_at: new Date().toISOString(),
+	updated_at: new Date().toISOString(),
+})
+
 describe('POST /api/introductions', () => {
 	test('should create cross-matchmaker introduction with both matchmaker IDs', async () => {
-		let mockIntroduction = {
+		let mockIntroduction = buildIntroRow({
 			id: '650e8400-e29b-41d4-a716-446655440001',
-			matchmaker_a_id: mockUserId,
-			matchmaker_b_id: otherMatchmakerId,
-			person_a_id: personAId,
-			person_b_id: personBId,
-			status: 'pending',
-			notes: null,
-			created_at: new Date().toISOString(),
-			updated_at: new Date().toISOString(),
-		}
+			matchmakerAId: mockUserId,
+			matchmakerBId: otherMatchmakerId,
+			personAId,
+			personBId,
+		})
 
 		let mockClient = createMockSupabaseClient({
-			from: mock((_table: string) => ({
-				select: mock((_columns: string) => ({
-					eq: mock((column: string, value: unknown) => ({
-						single: mock(() => {
-							if (value === personAId) {
-								return { data: { id: personAId, matchmaker_id: mockUserId }, error: null }
-							}
-							if (value === personBId) {
-								return { data: { id: personBId, matchmaker_id: otherMatchmakerId }, error: null }
-							}
-							return { data: null, error: null }
-						}),
-					})),
-				})),
-				insert: mock((_data: any) => ({
-					select: mock(() => ({
-						single: mock(() => ({
-							data: mockIntroduction,
-							error: null,
+			from: mock((table: string) => {
+				if (table === 'people') {
+					return {
+						select: mock((_columns: string) => ({
+							eq: mock((_column: string, value: unknown) => ({
+								maybeSingle: mock(() => {
+									if (value === personAId) {
+										return { data: buildPersonRow(personAId, mockUserId), error: null }
+									}
+									if (value === personBId) {
+										return {
+											data: buildPersonRow(personBId, otherMatchmakerId),
+											error: null,
+										}
+									}
+									return { data: null, error: null }
+								}),
+							})),
 						})),
-					})),
-				})),
-			})),
+					}
+				}
+				if (table === 'introductions') {
+					return {
+						insert: mock((_data: any) => ({
+							select: mock(() => ({
+								single: mock(() => ({
+									data: mockIntroduction,
+									error: null,
+								})),
+							})),
+						})),
+					}
+				}
+				throw new Error(`unexpected table: ${table}`)
+			}),
 		})
 
 		let app = new Hono<{ Variables: Variables }>()
@@ -106,21 +148,32 @@ describe('POST /api/introductions', () => {
 		let thirdPartyMatchmaker = '333e8400-e29b-41d4-a716-446655440033'
 
 		let mockClient = createMockSupabaseClient({
-			from: mock((_table: string) => ({
-				select: mock((_columns: string) => ({
-					eq: mock((_column: string, value: unknown) => ({
-						single: mock(() => {
-							if (value === personAId) {
-								return { data: { id: personAId, matchmaker_id: otherMatchmakerId }, error: null }
-							}
-							if (value === personBId) {
-								return { data: { id: personBId, matchmaker_id: thirdPartyMatchmaker }, error: null }
-							}
-							return { data: null, error: null }
-						}),
-					})),
-				})),
-			})),
+			from: mock((table: string) => {
+				if (table === 'people') {
+					return {
+						select: mock((_columns: string) => ({
+							eq: mock((_column: string, value: unknown) => ({
+								maybeSingle: mock(() => {
+									if (value === personAId) {
+										return {
+											data: buildPersonRow(personAId, otherMatchmakerId),
+											error: null,
+										}
+									}
+									if (value === personBId) {
+										return {
+											data: buildPersonRow(personBId, thirdPartyMatchmaker),
+											error: null,
+										}
+									}
+									return { data: null, error: null }
+								}),
+							})),
+						})),
+					}
+				}
+				throw new Error(`unexpected table: ${table}`)
+			}),
 		})
 
 		let app = new Hono<{ Variables: Variables }>()

--- a/backend/tests/services/introductions.test.ts
+++ b/backend/tests/services/introductions.test.ts
@@ -1,10 +1,19 @@
 import { describe, test, expect } from 'bun:test'
-import { createPerson, type Introduction } from '@matchmaker/shared'
+import { createPerson } from '@matchmaker/shared'
 import { createIntroduction } from '../../src/services/introductions'
 import {
 	InMemoryIntroductionRepository,
 	InMemoryPersonRepository,
 } from '../fakes/in-memory-repositories'
+
+type ServiceResult = Awaited<ReturnType<typeof createIntroduction>>
+type OkResult = Extract<ServiceResult, { error: null }>
+
+function assertOk(result: ServiceResult): asserts result is OkResult {
+	if (result.error !== null) {
+		throw new Error(`expected ok result, got error: ${result.error.message}`)
+	}
+}
 
 let now = new Date('2026-01-01T00:00:00.000Z')
 
@@ -40,8 +49,8 @@ describe('createIntroduction service', () => {
 		})
 
 		// Assert
-		expect(result.error).toBeNull()
-		let intro = result.data as Introduction
+		assertOk(result)
+		let intro = result.data
 		expect(intro.matchmakerAId).toBe('mm-user')
 		expect(intro.matchmakerBId).toBe('mm-other')
 		expect(intro.personAId).toBe('p-a')
@@ -67,10 +76,9 @@ describe('createIntroduction service', () => {
 		})
 
 		// Assert
-		expect(result.error).toBeNull()
-		let intro = result.data as Introduction
-		expect(intro.matchmakerAId).toBe('mm-other')
-		expect(intro.matchmakerBId).toBe('mm-user')
+		assertOk(result)
+		expect(result.data.matchmakerAId).toBe('mm-other')
+		expect(result.data.matchmakerBId).toBe('mm-user')
 	})
 
 	test('creates introduction when user owns both people', async () => {
@@ -88,10 +96,9 @@ describe('createIntroduction service', () => {
 		})
 
 		// Assert
-		expect(result.error).toBeNull()
-		let intro = result.data as Introduction
-		expect(intro.matchmakerAId).toBe('mm-user')
-		expect(intro.matchmakerBId).toBe('mm-user')
+		assertOk(result)
+		expect(result.data.matchmakerAId).toBe('mm-user')
+		expect(result.data.matchmakerBId).toBe('mm-user')
 	})
 
 	test('passes notes through to the created introduction', async () => {
@@ -110,8 +117,8 @@ describe('createIntroduction service', () => {
 		})
 
 		// Assert
-		expect(result.error).toBeNull()
-		expect((result.data as Introduction).notes).toBe('they both love climbing')
+		assertOk(result)
+		expect(result.data.notes).toBe('they both love climbing')
 	})
 
 	test('returns 404 when person A is not found', async () => {
@@ -189,8 +196,8 @@ describe('createIntroduction service', () => {
 		})
 
 		// Assert
-		expect(result.error).toBeNull()
-		let intro = result.data as Introduction
+		assertOk(result)
+		let intro = result.data
 		expect(typeof intro.id).toBe('string')
 		expect(intro.id.length).toBeGreaterThan(0)
 		expect(intro.createdAt.getTime()).toBe(intro.updatedAt.getTime())

--- a/backend/tests/services/introductions.test.ts
+++ b/backend/tests/services/introductions.test.ts
@@ -1,0 +1,198 @@
+import { describe, test, expect } from 'bun:test'
+import { createPerson, type Introduction } from '@matchmaker/shared'
+import { createIntroduction } from '../../src/services/introductions'
+import {
+	InMemoryIntroductionRepository,
+	InMemoryPersonRepository,
+} from '../fakes/in-memory-repositories'
+
+let now = new Date('2026-01-01T00:00:00.000Z')
+
+let buildPerson = (overrides: { id: string; matchmakerId?: string | null }) =>
+	createPerson({
+		id: overrides.id,
+		matchmakerId: overrides.matchmakerId ?? 'mm-1',
+		name: `Person ${overrides.id}`,
+		age: 30,
+		location: null,
+		gender: null,
+		preferences: null,
+		personality: null,
+		notes: null,
+		active: true,
+		createdAt: now,
+		updatedAt: now,
+	})
+
+describe('createIntroduction service', () => {
+	test('creates introduction when user owns person A only', async () => {
+		// Arrange
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-user' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-other' })
+		let personRepo = new InMemoryPersonRepository([personA, personB])
+		let introRepo = new InMemoryIntroductionRepository()
+
+		// Act
+		let result = await createIntroduction(personRepo, introRepo, {
+			person_a_id: 'p-a',
+			person_b_id: 'p-b',
+			userId: 'mm-user',
+		})
+
+		// Assert
+		expect(result.error).toBeNull()
+		let intro = result.data as Introduction
+		expect(intro.matchmakerAId).toBe('mm-user')
+		expect(intro.matchmakerBId).toBe('mm-other')
+		expect(intro.personAId).toBe('p-a')
+		expect(intro.personBId).toBe('p-b')
+		expect(intro.status).toBe('pending')
+		expect(intro.notes).toBeNull()
+		let persisted = await introRepo.findById(intro.id)
+		expect(persisted).not.toBeNull()
+	})
+
+	test('creates introduction when user owns person B only', async () => {
+		// Arrange
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-other' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-user' })
+		let personRepo = new InMemoryPersonRepository([personA, personB])
+		let introRepo = new InMemoryIntroductionRepository()
+
+		// Act
+		let result = await createIntroduction(personRepo, introRepo, {
+			person_a_id: 'p-a',
+			person_b_id: 'p-b',
+			userId: 'mm-user',
+		})
+
+		// Assert
+		expect(result.error).toBeNull()
+		let intro = result.data as Introduction
+		expect(intro.matchmakerAId).toBe('mm-other')
+		expect(intro.matchmakerBId).toBe('mm-user')
+	})
+
+	test('creates introduction when user owns both people', async () => {
+		// Arrange
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-user' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-user' })
+		let personRepo = new InMemoryPersonRepository([personA, personB])
+		let introRepo = new InMemoryIntroductionRepository()
+
+		// Act
+		let result = await createIntroduction(personRepo, introRepo, {
+			person_a_id: 'p-a',
+			person_b_id: 'p-b',
+			userId: 'mm-user',
+		})
+
+		// Assert
+		expect(result.error).toBeNull()
+		let intro = result.data as Introduction
+		expect(intro.matchmakerAId).toBe('mm-user')
+		expect(intro.matchmakerBId).toBe('mm-user')
+	})
+
+	test('passes notes through to the created introduction', async () => {
+		// Arrange
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-user' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-other' })
+		let personRepo = new InMemoryPersonRepository([personA, personB])
+		let introRepo = new InMemoryIntroductionRepository()
+
+		// Act
+		let result = await createIntroduction(personRepo, introRepo, {
+			person_a_id: 'p-a',
+			person_b_id: 'p-b',
+			notes: 'they both love climbing',
+			userId: 'mm-user',
+		})
+
+		// Assert
+		expect(result.error).toBeNull()
+		expect((result.data as Introduction).notes).toBe('they both love climbing')
+	})
+
+	test('returns 404 when person A is not found', async () => {
+		// Arrange
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-user' })
+		let personRepo = new InMemoryPersonRepository([personB])
+		let introRepo = new InMemoryIntroductionRepository()
+
+		// Act
+		let result = await createIntroduction(personRepo, introRepo, {
+			person_a_id: 'p-missing',
+			person_b_id: 'p-b',
+			userId: 'mm-user',
+		})
+
+		// Assert
+		expect(result.data).toBeNull()
+		expect(result.error).toEqual({ message: 'Person A not found', status: 404 })
+	})
+
+	test('returns 404 when person B is not found', async () => {
+		// Arrange
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-user' })
+		let personRepo = new InMemoryPersonRepository([personA])
+		let introRepo = new InMemoryIntroductionRepository()
+
+		// Act
+		let result = await createIntroduction(personRepo, introRepo, {
+			person_a_id: 'p-a',
+			person_b_id: 'p-missing',
+			userId: 'mm-user',
+		})
+
+		// Assert
+		expect(result.data).toBeNull()
+		expect(result.error).toEqual({ message: 'Person B not found', status: 404 })
+	})
+
+	test('returns 403 when user owns neither person and does not persist', async () => {
+		// Arrange
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-other-1' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-other-2' })
+		let personRepo = new InMemoryPersonRepository([personA, personB])
+		let introRepo = new InMemoryIntroductionRepository()
+
+		// Act
+		let result = await createIntroduction(personRepo, introRepo, {
+			person_a_id: 'p-a',
+			person_b_id: 'p-b',
+			userId: 'mm-user',
+		})
+
+		// Assert
+		expect(result.data).toBeNull()
+		expect(result.error).toEqual({
+			message: 'You must own at least one person in the introduction',
+			status: 403,
+		})
+		expect(await introRepo.findByMatchmaker('mm-other-1')).toHaveLength(0)
+		expect(await introRepo.findByMatchmaker('mm-other-2')).toHaveLength(0)
+	})
+
+	test('generates a non-empty id and sets createdAt === updatedAt', async () => {
+		// Arrange
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-user' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-other' })
+		let personRepo = new InMemoryPersonRepository([personA, personB])
+		let introRepo = new InMemoryIntroductionRepository()
+
+		// Act
+		let result = await createIntroduction(personRepo, introRepo, {
+			person_a_id: 'p-a',
+			person_b_id: 'p-b',
+			userId: 'mm-user',
+		})
+
+		// Assert
+		expect(result.error).toBeNull()
+		let intro = result.data as Introduction
+		expect(typeof intro.id).toBe('string')
+		expect(intro.id.length).toBeGreaterThan(0)
+		expect(intro.createdAt.getTime()).toBe(intro.updatedAt.getTime())
+	})
+})

--- a/packages/shared/src/domain/authorization/authorization-service.ts
+++ b/packages/shared/src/domain/authorization/authorization-service.ts
@@ -22,8 +22,20 @@ export function canMatchmakerEditIntroduction(
 	)
 }
 
+export function canMatchmakerCreateIntroduction(
+	matchmakerId: string,
+	personA: Person,
+	personB: Person,
+): boolean {
+	return (
+		canMatchmakerAccessPerson(matchmakerId, personA) ||
+		canMatchmakerAccessPerson(matchmakerId, personB)
+	)
+}
+
 export let AuthorizationService = Object.freeze({
 	canMatchmakerAccessPerson,
 	canMatchmakerRecordDecision,
 	canMatchmakerEditIntroduction,
+	canMatchmakerCreateIntroduction,
 })

--- a/packages/shared/tests/domain/authorization/authorization-service.test.ts
+++ b/packages/shared/tests/domain/authorization/authorization-service.test.ts
@@ -83,3 +83,45 @@ describe('AuthorizationService.canMatchmakerEditIntroduction', () => {
 		)
 	})
 })
+
+describe('AuthorizationService.canMatchmakerCreateIntroduction', () => {
+	test('allows when matchmaker owns person A only', () => {
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-owner' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-other' })
+		expect(
+			AuthorizationService.canMatchmakerCreateIntroduction('mm-owner', personA, personB),
+		).toBe(true)
+	})
+
+	test('allows when matchmaker owns person B only', () => {
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-other' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-owner' })
+		expect(
+			AuthorizationService.canMatchmakerCreateIntroduction('mm-owner', personA, personB),
+		).toBe(true)
+	})
+
+	test('allows when matchmaker owns both people', () => {
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-owner' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-owner' })
+		expect(
+			AuthorizationService.canMatchmakerCreateIntroduction('mm-owner', personA, personB),
+		).toBe(true)
+	})
+
+	test('denies when matchmaker owns neither person', () => {
+		let personA = buildPerson({ id: 'p-a', matchmakerId: 'mm-other-1' })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: 'mm-other-2' })
+		expect(
+			AuthorizationService.canMatchmakerCreateIntroduction('mm-owner', personA, personB),
+		).toBe(false)
+	})
+
+	test('denies when both people have no matchmaker', () => {
+		let personA = buildPerson({ id: 'p-a', matchmakerId: null })
+		let personB = buildPerson({ id: 'p-b', matchmakerId: null })
+		expect(
+			AuthorizationService.canMatchmakerCreateIntroduction('mm-owner', personA, personB),
+		).toBe(false)
+	})
+})


### PR DESCRIPTION
## Summary
- Rewrites `createIntroduction` to depend on `IPersonRepository` + `IIntroductionRepository` instead of `SupabaseClient`; service is now a thin orchestrator (load → authorize → build → persist) unit-testable with in-memory fakes.
- Adds `AuthorizationService.canMatchmakerCreateIntroduction` so the ownership rule ("requester owns at least one of the two people") is a framework-free domain rule instead of inline DB queries.
- Wires the POST `/api/introductions` route to the refactored service via `SupabasePersonRepository` + `SupabaseIntroductionRepository`, mapping the returned domain `Introduction` to the existing snake_case response shape. GET and PUT handlers are intentionally unchanged (follow-up scope).

Closes #57.

### Acceptance checklist
- [x] `introductions.ts` has no import of `@supabase/supabase-js`
- [x] Authorization delegates to `AuthorizationService`
- [x] Unit tests use in-memory fakes — no Supabase mocks
- [x] Covers happy path, unauthorized cross-matchmaker introduction, missing person, notes pass-through
- [x] Existing integration tests still pass (`backend` 266/266, `packages/shared` 158/158)

### Notes
- Preserved existing "at least one person owned" rule; issue background text said "both", but current code/test/error message all enforce "at least one" and that behavior has shipped. Changing the rule would be a separate user-visible decision.
- Added a 422 path for the (currently unreachable at the route layer) case where an authorized side's counterpart has `matchmakerId === null`; the domain `Introduction` entity forbids nullable matchmaker ids, so the service has to reject rather than fabricate.

## Test plan
- [x] `bun test` in `packages/shared` — all green, including 5 new authorization cases
- [x] `bun test` in `backend` — all green, including 8 new service unit tests and 2 updated POST route tests
- [x] `grep -n "@supabase/supabase-js\|SupabaseClient" backend/src/services/introductions.ts` returns nothing
- [ ] Manual smoke via MCP `create_introduction` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)