### PR TITLE
perf(backend): parallelize person lookups in createIntroduction

### DIFF
--- a/backend/src/services/introductions.ts
+++ b/backend/src/services/introductions.ts
@@ -24,12 +24,15 @@ export let createIntroduction = async (
 	introductionRepo: IIntroductionRepository,
 	params: CreateIntroductionParams,
 ): Promise<IntroductionResult> => {
-	let personA = await personRepo.findById(params.person_a_id)
+	let [personA, personB] = await Promise.all([
+		personRepo.findById(params.person_a_id),
+		personRepo.findById(params.person_b_id),
+	])
+
 	if (!personA) {
 		return { data: null, error: { message: 'Person A not found', status: 404 } }
 	}
 
-	let personB = await personRepo.findById(params.person_b_id)
 	if (!personB) {
 		return { data: null, error: { message: 'Person B not found', status: 404 } }
 	}


### PR DESCRIPTION
## Summary

Rebased version of #49 onto current main. The two person lookups in `createIntroduction` are independent, so run them concurrently via `Promise.all` to reduce latency.

Original PR #49 was written against the old `supabaseClient` direct-call shape and conflicted with main's refactor to the `personRepo` abstraction. This branch applies the same perf intent to the new repository shape.

Fixes #25
Replaces #49

## Test plan

- [x] `npm run test:backend` — 346 pass

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>