### PR TITLE
fix(gateway): await rejection assertions and narrow client type

### DIFF
--- a/gateway/src/store/conversations.ts
+++ b/gateway/src/store/conversations.ts
@@ -1,4 +1,3 @@
-import type { SupabaseClient } from '@supabase/supabase-js'
 import { z } from 'zod'
 
 export type ConversationMessage = {
@@ -9,6 +8,29 @@ export type ConversationMessage = {
 	provider?: string
 	senderId?: string
 	createdAt?: string
+}
+
+type DbError = { message: string }
+type InsertResult = { error: DbError | null }
+type SelectResult = { data: unknown[] | null; error: DbError | null }
+
+export interface ConversationStoreClient {
+	from(table: string): {
+		insert(values: Record<string, unknown>): PromiseLike<InsertResult>
+		select(columns: string): {
+			eq(
+				column: string,
+				value: string,
+			): {
+				order(
+					column: string,
+					opts: { ascending: boolean },
+				): {
+					limit(count: number): PromiseLike<SelectResult>
+				}
+			}
+		}
+	}
 }
 
 export let dbRowSchema = z.object({
@@ -33,7 +55,7 @@ function toMessage(row: z.infer<typeof dbRowSchema>): ConversationMessage {
 	}
 }
 
-export function createConversationStore(client: SupabaseClient) {
+export function createConversationStore(client: ConversationStoreClient) {
 	return {
 		async save(message: Omit<ConversationMessage, 'id' | 'createdAt'>) {
 			let { error } = await client.from('conversations').insert({

--- a/gateway/tests/store/conversations.test.ts
+++ b/gateway/tests/store/conversations.test.ts
@@ -1,29 +1,28 @@
 import { describe, test, expect, mock, beforeEach } from 'bun:test'
-import type { SupabaseClient } from '@supabase/supabase-js'
-import { createConversationStore } from '../../src/store/conversations'
+import {
+	createConversationStore,
+	type ConversationStoreClient,
+} from '../../src/store/conversations'
 
-function createMockSupabaseClient(overrides: { from?: any } = {}): SupabaseClient {
-	let defaultFrom = mock((_table: string) => ({
-		insert: mock(() => ({ error: null })),
-		select: mock(() => ({
-			eq: mock(() => ({
-				order: mock(() => ({
-					limit: mock(() => ({
-						data: [],
-						error: null,
-					})),
-					data: [],
-					error: null,
-				})),
-			})),
-		})),
-	}))
+type FromFn = ConversationStoreClient['from']
 
-	return { from: overrides.from || defaultFrom } as unknown as SupabaseClient
+function createMockSupabaseClient(overrides: { from?: FromFn } = {}): ConversationStoreClient {
+	let defaultFrom: FromFn = (_table: string) => ({
+		insert: () => Promise.resolve({ error: null }),
+		select: () => ({
+			eq: () => ({
+				order: () => ({
+					limit: () => Promise.resolve({ data: [], error: null }),
+				}),
+			}),
+		}),
+	})
+
+	return { from: overrides.from || defaultFrom }
 }
 
 describe('ConversationStore', () => {
-	let mockClient: SupabaseClient
+	let mockClient: ConversationStoreClient
 	let store: ReturnType<typeof createConversationStore>
 
 	beforeEach(() => {
@@ -33,11 +32,18 @@ describe('ConversationStore', () => {
 
 	describe('save', () => {
 		test('inserts message with correct threadId, role, and content', async () => {
-			let insertMock = mock(() => ({ error: null }))
+			let insertMock = mock(() => Promise.resolve({ error: null }))
 			mockClient = createMockSupabaseClient({
-				from: mock((_table: string) => ({
+				from: (_table: string) => ({
 					insert: insertMock,
-				})),
+					select: () => ({
+						eq: () => ({
+							order: () => ({
+								limit: () => Promise.resolve({ data: [], error: null }),
+							}),
+						}),
+					}),
+				}),
 			})
 			store = createConversationStore(mockClient)
 
@@ -60,13 +66,20 @@ describe('ConversationStore', () => {
 
 		test('throws on Supabase error', async () => {
 			mockClient = createMockSupabaseClient({
-				from: mock((_table: string) => ({
-					insert: mock(() => ({ error: { message: 'insert failed' } })),
-				})),
+				from: (_table: string) => ({
+					insert: () => Promise.resolve({ error: { message: 'insert failed' } }),
+					select: () => ({
+						eq: () => ({
+							order: () => ({
+								limit: () => Promise.resolve({ data: [], error: null }),
+							}),
+						}),
+					}),
+				}),
 			})
 			store = createConversationStore(mockClient)
 
-			expect(
+			await expect(
 				store.save({
 					threadId: 'thread-abc',
 					role: 'user',
@@ -84,18 +97,16 @@ describe('ConversationStore', () => {
 			]
 
 			mockClient = createMockSupabaseClient({
-				from: mock((_table: string) => ({
-					select: mock(() => ({
-						eq: mock(() => ({
-							order: mock(() => ({
-								limit: mock(() => ({
-									data: mockMessages,
-									error: null,
-								})),
-							})),
-						})),
-					})),
-				})),
+				from: (_table: string) => ({
+					insert: () => Promise.resolve({ error: null }),
+					select: () => ({
+						eq: () => ({
+							order: () => ({
+								limit: () => Promise.resolve({ data: mockMessages, error: null }),
+							}),
+						}),
+					}),
+				}),
 			})
 			store = createConversationStore(mockClient)
 
@@ -109,24 +120,27 @@ describe('ConversationStore', () => {
 		})
 
 		test('respects limit parameter', async () => {
-			let limitMock = mock(() => ({
-				data: [
-					{ id: '4', thread_id: 'thread-abc', role: 'user', content: 'msg4', provider: null, sender_id: null, created_at: '2026-01-01T00:00:04Z' },
-					{ id: '5', thread_id: 'thread-abc', role: 'assistant', content: 'msg5', provider: null, sender_id: null, created_at: '2026-01-01T00:00:05Z' },
-				],
-				error: null,
-			}))
+			let limitMock = mock(() =>
+				Promise.resolve({
+					data: [
+						{ id: '4', thread_id: 'thread-abc', role: 'user', content: 'msg4', provider: null, sender_id: null, created_at: '2026-01-01T00:00:04Z' },
+						{ id: '5', thread_id: 'thread-abc', role: 'assistant', content: 'msg5', provider: null, sender_id: null, created_at: '2026-01-01T00:00:05Z' },
+					],
+					error: null,
+				}),
+			)
 
 			mockClient = createMockSupabaseClient({
-				from: mock((_table: string) => ({
-					select: mock(() => ({
-						eq: mock(() => ({
-							order: mock(() => ({
+				from: (_table: string) => ({
+					insert: () => Promise.resolve({ error: null }),
+					select: () => ({
+						eq: () => ({
+							order: () => ({
 								limit: limitMock,
-							})),
-						})),
-					})),
-				})),
+							}),
+						}),
+					}),
+				}),
 			})
 			store = createConversationStore(mockClient)
 
@@ -143,22 +157,20 @@ describe('ConversationStore', () => {
 
 		test('throws on Supabase error', async () => {
 			mockClient = createMockSupabaseClient({
-				from: mock((_table: string) => ({
-					select: mock(() => ({
-						eq: mock(() => ({
-							order: mock(() => ({
-								limit: mock(() => ({
-									data: null,
-									error: { message: 'query failed' },
-								})),
-							})),
-						})),
-					})),
-				})),
+				from: (_table: string) => ({
+					insert: () => Promise.resolve({ error: null }),
+					select: () => ({
+						eq: () => ({
+							order: () => ({
+								limit: () => Promise.resolve({ data: null, error: { message: 'query failed' } }),
+							}),
+						}),
+					}),
+				}),
 			})
 			store = createConversationStore(mockClient)
 
-			expect(store.getHistory('thread-abc', 10)).rejects.toThrow('query failed')
+			await expect(store.getHistory('thread-abc', 10)).rejects.toThrow('query failed')
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Awaits `expect(...).rejects.toThrow(...)` in conversation store tests so a regressed (non-throwing) implementation can't pass silently
- Replaces `SupabaseClient` parameter with a narrow `ConversationStoreClient` interface; lets tests drop the `as unknown as SupabaseClient` cast and tightens the contract
- Addresses items #4 and #5 from PR #43 review

## Test plan
- [ ] `cd gateway && bun test` passes
- [ ] No new tsc errors (pre-existing tech debt unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)