### PR TITLE
fix(gateway): document service_role-only access on conversations RLS

### DIFF
--- a/supabase/migrations/20260329000000_add_conversations.sql
+++ b/supabase/migrations/20260329000000_add_conversations.sql
@@ -11,3 +11,10 @@ CREATE TABLE conversations (
 CREATE INDEX idx_conversations_thread ON conversations(thread_id, created_at);
 
 ALTER TABLE conversations ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE conversations IS
+  'Gateway conversation history. Accessed only via the service_role key '
+  'from the webhook-handling gateway; RLS is enabled with no policies so '
+  'anon/authenticated keys are denied by default. If a future caller needs '
+  'anon/authenticated access, add explicit CREATE POLICY statements in a '
+  'follow-up migration.';


### PR DESCRIPTION
## Summary
- Adds a SQL `COMMENT ON TABLE` to the conversations migration making it explicit that RLS-with-no-policies is intentional: the gateway accesses this table only via the service_role key
- Migration has not been applied to prod yet (PR #43 unmerged), so editing in place rather than adding a follow-up migration
- Addresses item #1 from PR #43 review

## Test plan
- [ ] `cd gateway && bun test` passes (drift test still green)
- [ ] When PR #43 merges, verify the comment is visible in prod via `\d+ public.conversations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)