### PR TITLE
fix(gateway): qualify conversations table with public schema

### DIFF
--- a/gateway/tests/store/conversationsSchemaDrift.test.ts
+++ b/gateway/tests/store/conversationsSchemaDrift.test.ts
@@ -14,7 +14,7 @@ import { join } from 'node:path'
 import { dbRowSchema } from '../../src/store/conversations'
 
 function extractColumnNames(sql: string): string[] {
-	let match = sql.match(/CREATE TABLE\s+conversations\s*\(([^;]+)\)\s*;/i)
+	let match = sql.match(/CREATE TABLE\s+(?:public\.)?conversations\s*\(([^;]+)\)\s*;/i)
 	if (!match) throw new Error('could not find CREATE TABLE conversations in migration')
 
 	let body = match[1] ?? ''

--- a/supabase/migrations/20260329000000_add_conversations.sql
+++ b/supabase/migrations/20260329000000_add_conversations.sql
@@ -1,4 +1,4 @@
-CREATE TABLE conversations (
+CREATE TABLE public.conversations (
   id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   thread_id   TEXT NOT NULL,
   role        TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
@@ -8,6 +8,6 @@ CREATE TABLE conversations (
   created_at  TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX idx_conversations_thread ON conversations(thread_id, created_at);
+CREATE INDEX idx_conversations_thread ON public.conversations(thread_id, created_at);
 
-ALTER TABLE conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.conversations ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary
- Qualifies `conversations` as `public.conversations` in CREATE TABLE / CREATE INDEX / ALTER TABLE statements, matching every other migration in the repo
- Updates the drift-test regex to accept the optional `public.` prefix so it keeps matching
- Addresses item #2 from PR #43 review

## Test plan
- [ ] `cd gateway && bun test` passes (drift test still green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)