### PR TITLE
refactor(gateway): split NewConversationMessage from ConversationMessage

### DIFF
--- a/gateway/src/store/conversations.ts
+++ b/gateway/src/store/conversations.ts
@@ -1,14 +1,17 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { z } from 'zod'
 
-export type ConversationMessage = {
-	id?: string
+export type NewConversationMessage = {
 	threadId: string
 	role: 'user' | 'assistant' | 'system'
 	content: string
 	provider?: string
 	senderId?: string
-	createdAt?: string
+}
+
+export type ConversationMessage = NewConversationMessage & {
+	id: string
+	createdAt: string
 }
 
 export let dbRowSchema = z.object({
@@ -35,7 +38,7 @@ function toMessage(row: z.infer<typeof dbRowSchema>): ConversationMessage {
 
 export function createConversationStore(client: SupabaseClient) {
 	return {
-		async save(message: Omit<ConversationMessage, 'id' | 'createdAt'>) {
+		async save(message: NewConversationMessage) {
 			let { error } = await client.from('conversations').insert({
 				thread_id: message.threadId,
 				role: message.role,

--- a/gateway/src/store/index.ts
+++ b/gateway/src/store/index.ts
@@ -1,1 +1,5 @@
-export { createConversationStore, type ConversationMessage } from './conversations'
+export {
+	createConversationStore,
+	type ConversationMessage,
+	type NewConversationMessage,
+} from './conversations'


### PR DESCRIPTION
## Summary
- Splits the conflated `ConversationMessage` type into a write shape (`NewConversationMessage`, no id/createdAt) and a read shape (`ConversationMessage`, with required id/createdAt)
- `save()` now takes `NewConversationMessage`; `getHistory()` still returns `ConversationMessage[]` but callers can rely on `id` and `createdAt` being populated without a non-null assertion
- Addresses item #6 from PR #43 review

## Test plan
- [ ] `cd gateway && bun test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)