### PR TITLE
fix: clean up type errors and add typecheck CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,3 +51,48 @@ jobs:
       - name: Run gateway tests
         working-directory: ./gateway
         run: bun test
+
+  typecheck:
+    name: Typecheck Packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install shared dependencies
+        working-directory: ./packages/shared
+        run: bun install --frozen-lockfile
+
+      - name: Install backend dependencies
+        working-directory: ./backend
+        run: bun install --frozen-lockfile
+
+      - name: Install MCP server dependencies
+        working-directory: ./mcp-server
+        run: bun install --frozen-lockfile
+
+      - name: Install gateway dependencies
+        working-directory: ./gateway
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck shared
+        working-directory: ./packages/shared
+        run: bun run typecheck
+
+      - name: Typecheck backend
+        working-directory: ./backend
+        run: bun run typecheck
+
+      - name: Typecheck MCP server
+        working-directory: ./mcp-server
+        run: bun run typecheck
+
+      - name: Typecheck gateway
+        working-directory: ./gateway
+        run: bun run typecheck

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
 		"test": "bun test",
 		"test:watch": "bun test --watch",
 		"test:coverage": "bun test --coverage",
+		"typecheck": "tsc --noEmit",
 		"format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\" \"*.json\"",
 		"format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\" \"*.json\""
 	},

--- a/backend/src/schemas/oauth.ts
+++ b/backend/src/schemas/oauth.ts
@@ -3,14 +3,10 @@ import { z } from 'zod'
 export let authorizeQuerySchema = z.object({
 	client_id: z.string().min(1, 'client_id is required'),
 	redirect_uri: z.string().url('redirect_uri must be a valid URL'),
-	response_type: z.literal('code', {
-		errorMap: () => ({ message: "response_type must be 'code'" }),
-	}),
+	response_type: z.literal('code', { message: "response_type must be 'code'" }),
 	state: z.string().min(1, 'state is required'),
 	code_challenge: z.string().min(43, 'code_challenge must be at least 43 characters'),
-	code_challenge_method: z.literal('S256', {
-		errorMap: () => ({ message: "code_challenge_method must be 'S256'" }),
-	}),
+	code_challenge_method: z.literal('S256', { message: "code_challenge_method must be 'S256'" }),
 })
 
 export type AuthorizeQuery = z.infer<typeof authorizeQuerySchema>

--- a/backend/tests/middleware/auth.test.ts
+++ b/backend/tests/middleware/auth.test.ts
@@ -12,7 +12,7 @@ describe('authMiddleware', () => {
 		let mockUserId = 'user-123'
 		let mockClient = createMockSupabaseClient({
 			auth: {
-				getUser: mock(async (token: string) => ({
+				getUser: mock(async (_token: string) => ({
 					data: { user: { id: mockUserId } },
 					error: null,
 				})),
@@ -70,7 +70,7 @@ describe('authMiddleware', () => {
 	test('should return 401 if token verification fails', async () => {
 		let mockClient = createMockSupabaseClient({
 			auth: {
-				getUser: mock(async (token: string) => ({
+				getUser: mock(async (_token: string) => ({
 					data: { user: null },
 					error: { message: 'Invalid token' },
 				})),
@@ -94,7 +94,7 @@ describe('authMiddleware', () => {
 	test('should return 401 if user not found', async () => {
 		let mockClient = createMockSupabaseClient({
 			auth: {
-				getUser: mock(async (token: string) => ({
+				getUser: mock(async (_token: string) => ({
 					data: { user: null },
 					error: null,
 				})),

--- a/backend/tests/routes/feedback.test.ts
+++ b/backend/tests/routes/feedback.test.ts
@@ -21,8 +21,8 @@ describe('POST /api/feedback', () => {
 		}
 
 		let mockClient = createMockSupabaseClient({
-			from: mock((table: string) => ({
-				insert: mock((data: any) => ({
+			from: mock((_table: string) => ({
+				insert: mock((_data: any) => ({
 					select: mock(() => ({
 						single: mock(() => ({
 							data: mockFeedback,
@@ -107,9 +107,9 @@ describe('GET /api/feedback', () => {
 		]
 
 		let mockClient = createMockSupabaseClient({
-			from: mock((table: string) => ({
-				select: mock((columns: string) => ({
-					eq: mock((column: string, value: any) => ({
+			from: mock((_table: string) => ({
+				select: mock((_columns: string) => ({
+					eq: mock((_column: string, _value: any) => ({
 						data: mockFeedback,
 						error: null,
 					})),
@@ -138,9 +138,9 @@ describe('GET /api/feedback', () => {
 
 	test('should return empty array if no feedback', async () => {
 		let mockClient = createMockSupabaseClient({
-			from: mock((table: string) => ({
-				select: mock((columns: string) => ({
-					eq: mock((column: string, value: any) => ({
+			from: mock((_table: string) => ({
+				select: mock((_columns: string) => ({
+					eq: mock((_column: string, _value: any) => ({
 						data: [],
 						error: null,
 					})),
@@ -180,9 +180,9 @@ describe('GET /api/feedback/:id', () => {
 		}
 
 		let mockClient = createMockSupabaseClient({
-			from: mock((table: string) => ({
-				select: mock((columns: string) => ({
-					eq: mock((column: string, value: any) => ({
+			from: mock((_table: string) => ({
+				select: mock((_columns: string) => ({
+					eq: mock((_column: string, _value: any) => ({
 						maybeSingle: mock(() => ({
 							data: mockFeedback,
 							error: null,
@@ -213,9 +213,9 @@ describe('GET /api/feedback/:id', () => {
 
 	test('should return 404 when feedback not found', async () => {
 		let mockClient = createMockSupabaseClient({
-			from: mock((table: string) => ({
-				select: mock((columns: string) => ({
-					eq: mock((column: string, value: any) => ({
+			from: mock((_table: string) => ({
+				select: mock((_columns: string) => ({
+					eq: mock((_column: string, _value: any) => ({
 						maybeSingle: mock(() => ({
 							data: null,
 							error: null,

--- a/backend/tests/routes/mcp-preferences.test.ts
+++ b/backend/tests/routes/mcp-preferences.test.ts
@@ -7,11 +7,14 @@ import { createMockSupabaseClient } from '../mocks/supabase'
  * Helper: send a tools/call JSON-RPC request to the MCP endpoint
  * and parse the JSON response to extract the tool result.
  */
+type ToolResult = { isError?: boolean; content: Array<{ type: string; text: string }> }
+type JsonRpcResponse = { result?: ToolResult }
+
 async function callTool(
 	app: Hono,
 	name: string,
 	args: Record<string, unknown>
-): Promise<{ isError?: boolean; content: Array<{ type: string; text: string }> }> {
+): Promise<ToolResult> {
 	let res = await app.fetch(
 		new Request('http://localhost/mcp', {
 			method: 'POST',
@@ -29,7 +32,7 @@ async function callTool(
 		})
 	)
 
-	let body = await res.json()
+	let body: JsonRpcResponse = JSON.parse(await res.text())
 	if (!body.result) throw new Error('No tool result found in JSON response')
 	return body.result
 }

--- a/backend/tests/routes/mcp.test.ts
+++ b/backend/tests/routes/mcp.test.ts
@@ -1,7 +1,25 @@
-import { describe, test, expect, beforeEach, mock, spyOn, afterEach } from 'bun:test'
+import { describe, test, expect, beforeEach, mock } from 'bun:test'
 import { Hono } from 'hono'
 import { createMcpRoutes } from '../../src/routes/mcp'
 import { createMockSupabaseClient } from '../mocks/supabase'
+
+type JsonRpcResponse = {
+	result?: {
+		serverInfo?: { name?: string }
+		prompts?: Array<{ name: string; description?: string }>
+		messages?: Array<{ content: { type: string; text?: string } }>
+		isError?: boolean
+		content?: Array<{ type: string; text?: string }>
+	}
+	error?: { code?: number; message?: string } | string
+	code?: number
+	message?: string
+}
+
+async function jsonBody(res: Response): Promise<JsonRpcResponse> {
+	let body: JsonRpcResponse = JSON.parse(await res.text())
+	return body
+}
 
 describe('MCP Routes', () => {
 	let app: Hono
@@ -150,8 +168,8 @@ describe('MCP Routes', () => {
 			expect(initRes.status).toBe(200)
 
 			// Parse JSON response to get initialization result
-			let initBody = await initRes.json()
-			expect(initBody.result.serverInfo.name).toBe('matchmaker-mcp')
+			let initBody = await jsonBody(initRes)
+			expect(initBody.result?.serverInfo?.name).toBe('matchmaker-mcp')
 		})
 	})
 
@@ -414,18 +432,18 @@ describe('MCP Routes', () => {
 				let res = await app.fetch(req)
 				expect(res.status).toBe(200)
 
-				let body = await res.json()
+				let body = await jsonBody(res)
 				let promptsListResult = body.result
 
 				expect(promptsListResult).not.toBeNull()
-				expect(promptsListResult.prompts).toBeArray()
-				expect(promptsListResult.prompts.length).toBeGreaterThan(0)
+				expect(promptsListResult?.prompts).toBeArray()
+				expect(promptsListResult?.prompts?.length).toBeGreaterThan(0)
 
-				let intakePrompt = promptsListResult.prompts.find(
-					(p: { name: string }) => p.name === 'matchmaker_interview'
+				let intakePrompt = promptsListResult?.prompts?.find(
+					p => p.name === 'matchmaker_interview'
 				)
 				expect(intakePrompt).toBeDefined()
-				expect(intakePrompt.description).toBeDefined()
+				expect(intakePrompt?.description).toBeDefined()
 			})
 		})
 
@@ -451,17 +469,16 @@ describe('MCP Routes', () => {
 				let res = await app.fetch(req)
 				expect(res.status).toBe(200)
 
-				let body = await res.json()
+				let body = await jsonBody(res)
 				let promptResult = body.result
 
 				expect(promptResult).not.toBeNull()
-				expect(promptResult.messages).toBeArray()
-				expect(promptResult.messages.length).toBeGreaterThan(0)
+				expect(promptResult?.messages).toBeArray()
+				expect(promptResult?.messages?.length).toBeGreaterThan(0)
 
-				// Check the prompt content includes expected text
-				let messageContent = promptResult.messages[0].content
-				expect(messageContent.type).toBe('text')
-				expect(messageContent.text).toContain('Phase 1')
+				let messageContent = promptResult?.messages?.[0]?.content
+				expect(messageContent?.type).toBe('text')
+				expect(messageContent?.text).toContain('Phase 1')
 			})
 
 			test('returns an error for unknown prompt name', async () => {
@@ -485,9 +502,11 @@ describe('MCP Routes', () => {
 				let res = await app.fetch(req)
 				expect(res.status).toBe(200) // MCP returns 200 with error in body
 
-				let body = await res.json()
+				let body = await jsonBody(res)
 				expect(body.error).not.toBeNull()
-				expect(body.error.message).toContain('unknown_prompt')
+				expect(typeof body.error === 'object' ? body.error?.message : undefined).toContain(
+					'unknown_prompt'
+				)
 			})
 		})
 	})
@@ -514,12 +533,13 @@ describe('MCP Routes', () => {
 
 			expect(loggedCalls.length).toBe(1)
 
-			// First arg should be timestamp
 			let firstCall = loggedCalls[0]
+			if (!firstCall) throw new Error('expected one logged call')
 			expect(firstCall[0]).toBe('2026-01-23T00:00:00.000Z')
 
-			// Second arg should be JSON with error details
-			let logData = JSON.parse(firstCall[1] as string)
+			let serialized = firstCall[1]
+			if (typeof serialized !== 'string') throw new Error('expected JSON string')
+			let logData = JSON.parse(serialized)
 			expect(logData.type).toBe('TestError')
 			expect(logData.path).toBe('/test/path')
 			expect(logData.status).toBe(500)
@@ -541,14 +561,15 @@ describe('MCP Routes', () => {
 			let res = await app.fetch(req)
 			expect(res.status).toBe(400)
 
-			let body = await res.json()
+			let body = await jsonBody(res)
 			// The MCP SDK or our handler returns an error object
 			// Check for either our custom format or JSON-RPC error format
+			let errorObj = typeof body.error === 'object' ? body.error : undefined
 			let hasError =
 				body.error === 'Invalid JSON' ||
-				body.error?.code === -32700 ||
+				errorObj?.code === -32700 ||
 				body.code === -32700 ||
-				(body.message && body.message.includes('Invalid JSON'))
+				(body.message ? body.message.includes('Invalid JSON') : false)
 			expect(hasError).toBe(true)
 		})
 
@@ -616,7 +637,7 @@ describe('MCP Routes', () => {
 			let res = await notFoundApp.fetch(req)
 			expect(res.status).toBe(200)
 
-			let body = await res.json()
+			let body = await jsonBody(res)
 			expect(body.result?.isError).toBe(true)
 			expect(body.result?.content?.[0]?.text).toBe('Error: Introduction not found')
 		})
@@ -677,14 +698,12 @@ describe('MCP Routes', () => {
 			let res = await errorApp.fetch(toolReq)
 			expect(res.status).toBe(200) // MCP returns 200 with error in body
 
-			let body = await res.json()
+			let body = await jsonBody(res)
 
 			// JSON response contains the tool result directly
 			expect(body.result?.isError).toBe(true)
 			expect(Array.isArray(body.result?.content)).toBe(true)
-			let textContent = body.result.content.find(
-				(c: { type: string; text?: string }) => c.type === 'text'
-			)
+			let textContent = body.result?.content?.find(c => c.type === 'text')
 			expect(textContent?.text).toMatch(/^Error:/)
 		})
 

--- a/backend/tests/routes/oauth-e2e.test.ts
+++ b/backend/tests/routes/oauth-e2e.test.ts
@@ -113,7 +113,7 @@ describe('End-to-End OAuth Flow', () => {
 		expect(resourceRes.status).toBe(200)
 		let resourceMetadata = (await resourceRes.json()) as ProtectedResourceMetadata
 
-		expect(resourceMetadata.authorization_servers[0].issuer).toBe('http://localhost')
+		expect(resourceMetadata.authorization_servers[0]?.issuer).toBe('http://localhost')
 
 		// Step 3: Register client dynamically
 		let registerReq = new Request('http://localhost/register', {
@@ -375,7 +375,7 @@ describe('End-to-End OAuth Flow', () => {
 
 		expect(tokenData.refresh_token).toBeDefined()
 		expect(typeof tokenData.refresh_token).toBe('string')
-		expect(tokenData.refresh_token.length).toBeGreaterThan(0)
+		expect(tokenData.refresh_token?.length).toBeGreaterThan(0)
 	})
 
 	test('authorization code can only be used once', async () => {

--- a/backend/tests/routes/well-known.test.ts
+++ b/backend/tests/routes/well-known.test.ts
@@ -145,7 +145,7 @@ describe('GET /.well-known/oauth-protected-resource', () => {
 		expect(body.authorization_servers).toBeDefined()
 		expect(Array.isArray(body.authorization_servers)).toBe(true)
 		expect(body.authorization_servers.length).toBeGreaterThan(0)
-		expect(body.authorization_servers[0].issuer).toBe('http://localhost')
+		expect(body.authorization_servers[0]?.issuer).toBe('http://localhost')
 	})
 
 	test('should include resource identifier', async () => {

--- a/backend/tests/schemas/mcpToolsPreferencesRoundtrip.test.ts
+++ b/backend/tests/schemas/mcpToolsPreferencesRoundtrip.test.ts
@@ -7,7 +7,12 @@
  */
 import { describe, test, expect } from 'bun:test'
 import { buildMcpToolList } from '@matchmaker/shared'
-import { aboutMeSchema, lookingForSchema, parsePreferences } from '../../src/schemas/preferences'
+import {
+	aboutMeSchema,
+	lookingForSchema,
+	parsePreferences,
+	type StructuredPreferences,
+} from '../../src/schemas/preferences'
 
 let tools = buildMcpToolList()
 
@@ -84,11 +89,12 @@ describe('update_person preferences JSON Schema round-trips through Zod', () => 
 	test('every advertised dealBreaker value is accepted by parsePreferences', () => {
 		let dealBreakers = getStringEnum(dealBreakersItems)
 		let parsed = parsePreferences({ dealBreakers })
-		expect(parsed.dealBreakers).toEqual(dealBreakers)
+		expect(parsed.dealBreakers?.length).toBe(dealBreakers.length)
+		expect(parsed.dealBreakers?.map(String)).toEqual(dealBreakers)
 	})
 
 	test('a maximally populated example using only advertised values round-trips intact', () => {
-		let example = {
+		let example: StructuredPreferences = {
 			aboutMe: {
 				height: 175,
 				build: 'athletic',

--- a/backend/tests/services/matchingAlgorithm.test.ts
+++ b/backend/tests/services/matchingAlgorithm.test.ts
@@ -39,7 +39,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].person.name).toBe('Bob')
+		expect(matches[0]?.person.name).toBe('Bob')
 	})
 
 	test('should exclude inactive people', () => {
@@ -67,7 +67,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].is_cross_matchmaker).toBe(false)
+		expect(matches[0]?.is_cross_matchmaker).toBe(false)
 	})
 
 	test('should flag is_cross_matchmaker correctly for different matchmaker', () => {
@@ -84,7 +84,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].is_cross_matchmaker).toBe(true)
+		expect(matches[0]?.is_cross_matchmaker).toBe(true)
 	})
 
 	test('should strip sensitive fields from cross-matchmaker results', () => {
@@ -104,7 +104,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].person).toEqual({
+		expect(matches[0]?.person).toEqual({
 			id: '111e8400-e29b-41d4-a716-446655440011',
 			name: 'Bob',
 			age: 28,
@@ -128,8 +128,8 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(typeof matches[0].match_explanation).toBe('string')
-		expect(matches[0].match_explanation.length).toBeGreaterThan(0)
+		expect(typeof matches[0]?.match_explanation).toBe('string')
+		expect(matches[0]?.match_explanation.length).toBeGreaterThan(0)
 	})
 
 	test('should include compatibility_score as a number', () => {
@@ -145,9 +145,9 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(typeof matches[0].compatibility_score).toBe('number')
-		expect(matches[0].compatibility_score).toBeGreaterThanOrEqual(0)
-		expect(matches[0].compatibility_score).toBeLessThanOrEqual(1)
+		expect(typeof matches[0]?.compatibility_score).toBe('number')
+		expect(matches[0]?.compatibility_score).toBeGreaterThanOrEqual(0)
+		expect(matches[0]?.compatibility_score).toBeLessThanOrEqual(1)
 	})
 
 	test('should score higher for same location', () => {
@@ -199,7 +199,9 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(2)
-		expect(matches[0].compatibility_score).toBeGreaterThanOrEqual(matches[1].compatibility_score)
+		let [first, second] = matches
+		if (!first || !second) throw new Error('expected two matches')
+		expect(first.compatibility_score).toBeGreaterThanOrEqual(second.compatibility_score)
 	})
 
 	test('should return empty array when no candidates', () => {
@@ -220,8 +222,10 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId, limit: 3 })
 
 		expect(matches).toHaveLength(3)
-		expect(matches[0].compatibility_score).toBeGreaterThanOrEqual(matches[1].compatibility_score)
-		expect(matches[1].compatibility_score).toBeGreaterThanOrEqual(matches[2].compatibility_score)
+		let [first, second, third] = matches
+		if (!first || !second || !third) throw new Error('expected three matches')
+		expect(first.compatibility_score).toBeGreaterThanOrEqual(second.compatibility_score)
+		expect(second.compatibility_score).toBeGreaterThanOrEqual(third.compatibility_score)
 	})
 
 	test('should include location in explanation when locations match', () => {
@@ -237,7 +241,7 @@ describe('findMatches', () => {
 
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
-		expect(matches[0].match_explanation).toContain('NYC')
+		expect(matches[0]?.match_explanation).toContain('NYC')
 	})
 
 	test('should only match women with men (opposite gender)', () => {
@@ -270,7 +274,7 @@ describe('findMatches', () => {
 		let matches = findMatches(femaleSubject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].person.name).toBe('Bob')
+		expect(matches[0]?.person.name).toBe('Bob')
 	})
 
 	test('should only match men with women (opposite gender)', () => {
@@ -396,7 +400,7 @@ describe('findMatches', () => {
 		let matches = findMatches(femaleSubject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].person.name).toBe('Bob')
+		expect(matches[0]?.person.name).toBe('Bob')
 	})
 
 	// --- Deal Breaker Filter Tests ---
@@ -431,7 +435,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subjectWithPrefs.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].person.name).toBe('Charlie')
+		expect(matches[0]?.person.name).toBe('Charlie')
 	})
 
 	test('should filter bidirectionally — candidate deal breaker eliminates subject', () => {
@@ -607,7 +611,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subjectWithPrefs.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].compatibility_score).toBeGreaterThan(0)
+		expect(matches[0]?.compatibility_score).toBeGreaterThan(0)
 	})
 
 	test('should score higher when candidate is in partial age range with only min', () => {
@@ -691,7 +695,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subjectWithPrefs.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].person.name).toBe('Charlie')
+		expect(matches[0]?.person.name).toBe('Charlie')
 	})
 
 	test('should compare religion case-insensitively', () => {
@@ -863,7 +867,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subjectWithPrefs.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].match_explanation).toContain('fitness')
+		expect(matches[0]?.match_explanation).toContain('fitness')
 	})
 
 	// --- Backward Compatibility Tests ---
@@ -893,7 +897,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subjectNull.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].compatibility_score).toBeGreaterThan(0)
+		expect(matches[0]?.compatibility_score).toBeGreaterThan(0)
 	})
 
 	test('should still work with old-format preferences (backward compatible)', () => {
@@ -921,7 +925,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subjectOld.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].compatibility_score).toBeGreaterThan(0)
+		expect(matches[0]?.compatibility_score).toBeGreaterThan(0)
 	})
 
 	// --- Seed Profile Tests ---
@@ -941,8 +945,8 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].is_cross_matchmaker).toBe(true)
-		expect(matches[0].person.name).toBe('Seed Bob')
+		expect(matches[0]?.is_cross_matchmaker).toBe(true)
+		expect(matches[0]?.person.name).toBe('Seed Bob')
 	})
 
 	test('should include seed profiles in match results alongside regular profiles', () => {
@@ -1148,7 +1152,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subjectWithPrefs.id, allPeople, { matchmakerId })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].match_explanation).toContain('income')
+		expect(matches[0]?.match_explanation).toContain('income')
 	})
 
 	// --- Height Scoring Tests ---
@@ -1359,7 +1363,7 @@ describe('findMatches', () => {
 		let matches = findMatches(subject.id, allPeople, { matchmakerId, excludeIds })
 
 		expect(matches).toHaveLength(1)
-		expect(matches[0].person.name).toBe('Keep')
+		expect(matches[0]?.person.name).toBe('Keep')
 	})
 
 	test('should apply decline reason penalty for tattoos keyword', () => {
@@ -1417,7 +1421,10 @@ describe('findMatches', () => {
 		let withPenalty = findMatches(subject.id, [subject, candidate], { matchmakerId, declineReasons })
 		let withoutPenalty = findMatches(subject.id, [subject, candidate], { matchmakerId })
 
-		expect(withPenalty[0].compatibility_score).toBe(withoutPenalty[0].compatibility_score)
+		let [withPenaltyFirst] = withPenalty
+		let [withoutPenaltyFirst] = withoutPenalty
+		if (!withPenaltyFirst || !withoutPenaltyFirst) throw new Error('expected one match each')
+		expect(withPenaltyFirst.compatibility_score).toBe(withoutPenaltyFirst.compatibility_score)
 	})
 
 	test('should cap decline penalty so score does not go below 0', () => {
@@ -1446,7 +1453,7 @@ describe('findMatches', () => {
 		]
 		let matches = findMatches(subject.id, [subject, candidate], { matchmakerId, declineReasons })
 
-		expect(matches[0].compatibility_score).toBeGreaterThanOrEqual(0)
+		expect(matches[0]?.compatibility_score).toBeGreaterThanOrEqual(0)
 	})
 
 	test('should apply penalty for smoker keyword variations', () => {
@@ -1497,7 +1504,10 @@ describe('findMatches', () => {
 		let withDecline = findMatches(subject.id, [subject, candidate], { matchmakerId, declineReasons })
 		let withoutDecline = findMatches(subject.id, [subject, candidate], { matchmakerId })
 
-		expect(withDecline[0].compatibility_score).toBe(withoutDecline[0].compatibility_score)
+		let [withDeclineFirst] = withDecline
+		let [withoutDeclineFirst] = withoutDecline
+		if (!withDeclineFirst || !withoutDeclineFirst) throw new Error('expected one match each')
+		expect(withDeclineFirst.compatibility_score).toBe(withoutDeclineFirst.compatibility_score)
 	})
 
 	test('should still apply penalty for valid piercing keyword in context', () => {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -15,11 +15,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"outDir": "./dist",
-		"baseUrl": ".",
-		"paths": {
-			"@/*": ["./src/*"]
-		}
+		"outDir": "./dist"
 	},
 	"include": ["src/**/*", "tests/**/*", "**/*.test.ts"],
 	"exclude": ["node_modules", "dist"]

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -8,7 +8,8 @@
 		"start": "bun src/index.ts",
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"test:coverage": "bun test --coverage"
+		"test:coverage": "bun test --coverage",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@matchmaker/shared": "workspace:*",

--- a/gateway/tests/router/webhook.test.ts
+++ b/gateway/tests/router/webhook.test.ts
@@ -47,7 +47,7 @@ describe('webhook router', () => {
 		)
 
 		expect(res.status).toBe(200)
-		let body = await res.json()
+		let body: { ok?: boolean } = JSON.parse(await res.text())
 		expect(body.ok).toBe(true)
 	})
 
@@ -85,12 +85,14 @@ describe('webhook router', () => {
 	})
 
 	test('verifyWebhook receives headers and body buffer without consuming the request stream', async () => {
-		let seenBodyText: string | null = null
-		let seenSignature: string | null = null
+		let captured: { bodyText: string | null; signature: string | null } = {
+			bodyText: null,
+			signature: null,
+		}
 		let adapter = createMockAdapter({
 			verifyWebhook: async ({ headers, body }) => {
-				seenBodyText = new TextDecoder().decode(body)
-				seenSignature = headers.get('x-signature')
+				captured.bodyText = new TextDecoder().decode(body)
+				captured.signature = headers.get('x-signature')
 				return true
 			},
 		})
@@ -111,8 +113,8 @@ describe('webhook router', () => {
 		)
 
 		expect(res.status).toBe(200)
-		expect(seenBodyText).toBe(payload)
-		expect(seenSignature).toBe('sig-xyz')
+		expect(captured.bodyText).toBe(payload)
+		expect(captured.signature).toBe('sig-xyz')
 	})
 
 	test('POST /webhook/:provider returns 400 when parseInbound throws', async () => {

--- a/gateway/tests/services/handle-inbound-message.test.ts
+++ b/gateway/tests/services/handle-inbound-message.test.ts
@@ -68,10 +68,12 @@ describe('HandleInboundMessage', () => {
 		await service.execute(adapter, {})
 
 		expect(sendReplyCalls).toHaveLength(1)
-		expect(sendReplyCalls[0].provider).toBe('test')
-		expect(sendReplyCalls[0].senderId).toBe('sender-123')
-		expect(sendReplyCalls[0].threadId).toBe('thread-456')
-		expect(sendReplyCalls[0].text.length).toBeGreaterThan(0)
+		let firstCall = sendReplyCalls[0]
+		if (!firstCall) throw new Error('expected one sendReply call')
+		expect(firstCall.provider).toBe('test')
+		expect(firstCall.senderId).toBe('sender-123')
+		expect(firstCall.threadId).toBe('thread-456')
+		expect(firstCall.text.length).toBeGreaterThan(0)
 	})
 
 	test('returns a fully-hydrated InboundMessage with resolved userId', async () => {

--- a/gateway/tests/store/conversations.test.ts
+++ b/gateway/tests/store/conversations.test.ts
@@ -32,7 +32,9 @@ describe('ConversationStore', () => {
 
 	describe('save', () => {
 		test('inserts message with correct threadId, role, and content', async () => {
-			let insertMock = mock(() => Promise.resolve({ error: null }))
+			let insertMock = mock((_data: Record<string, unknown>) =>
+				Promise.resolve({ error: null }),
+			)
 			mockClient = createMockSupabaseClient({
 				from: (_table: string) => ({
 					insert: insertMock,
@@ -56,7 +58,9 @@ describe('ConversationStore', () => {
 			})
 
 			expect(insertMock).toHaveBeenCalledTimes(1)
-			let insertedData = insertMock.mock.calls[0]![0] as Record<string, unknown>
+			let firstCall = insertMock.mock.calls[0]
+			if (!firstCall) throw new Error('expected insert to be called once')
+			let insertedData = firstCall[0]
 			expect(insertedData.thread_id).toBe('thread-abc')
 			expect(insertedData.role).toBe('user')
 			expect(insertedData.content).toBe('Hello matchmaker')

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -15,11 +15,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"outDir": "./dist",
-		"baseUrl": ".",
-		"paths": {
-			"@/*": ["./src/*"]
-		}
+		"outDir": "./dist"
 	},
 	"include": ["src/**/*", "tests/**/*"],
 	"exclude": ["node_modules", "dist"]

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -10,6 +10,7 @@
 		"test": "bun test --preload ./tests/setup.ts",
 		"test:watch": "bun test --watch --preload ./tests/setup.ts",
 		"test:coverage": "bun test --coverage --preload ./tests/setup.ts",
+		"typecheck": "tsc --noEmit",
 		"format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\" \"*.json\"",
 		"format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\" \"*.json\""
 	},

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -44,7 +44,11 @@ export function createServer(apiClient: IApiClient) {
 			if (!isValidToolName(name)) {
 				throw new Error(`Unknown tool: ${name}`)
 			}
-			return await toolHandlers[name](args)
+			let handler = toolHandlers[name]
+			if (!handler) {
+				throw new Error(`No handler registered for tool: ${name}`)
+			}
+			return await handler(args)
 		} catch (error) {
 			let errorMessage = 'Unknown error'
 			if (error instanceof Error) {

--- a/mcp-server/tests/index.test.ts
+++ b/mcp-server/tests/index.test.ts
@@ -11,6 +11,14 @@ import type {
 	PersonPersonality,
 } from '../src/api'
 
+type Handlers = ReturnType<typeof createToolHandlers>
+
+function callHandler<T extends keyof Handlers>(handlers: Handlers, name: T, args: unknown) {
+	let handler = handlers[name]
+	if (!handler) throw new Error(`no handler registered for tool: ${String(name)}`)
+	return handler(args)
+}
+
 function createMockApiClient(overrides?: Partial<IApiClient>): IApiClient {
 	return {
 		addPerson: mock(
@@ -185,10 +193,9 @@ describe('MCP Server', () => {
 			})
 		)
 
-		let mockApiClient = {
+		let mockApiClient = createMockApiClient({
 			addPerson: mockAddPerson,
-			listPeople: mock(async (): Promise<Person[]> => []),
-		} as IApiClient
+		})
 
 		// Simulate what the handler does
 		let personName = 'John Doe'
@@ -221,19 +228,9 @@ describe('MCP Server', () => {
 			]
 		)
 
-		let mockApiClient = {
-			addPerson: mock(
-				async (_name: string): Promise<Person> => ({
-					id: 'test-id',
-					name: _name,
-					matchmaker_id: 'user-id',
-					active: true,
-					created_at: new Date().toISOString(),
-					updated_at: new Date().toISOString(),
-				})
-			),
+		let mockApiClient = createMockApiClient({
 			listPeople: mockListPeople,
-		} as IApiClient
+		})
 
 		let result = await mockApiClient.listPeople()
 
@@ -663,7 +660,7 @@ describe('Handler structuredContent', () => {
 			getPerson: mock(async () => person),
 		})
 		let handlers = createToolHandlers(mockClient)
-		let result = await handlers.get_person({ id: 'p1' })
+		let result = await callHandler(handlers, 'get_person', { id: 'p1' })
 
 		expect(result.content[0]?.text).toBe(JSON.stringify(person, null, 2))
 		expect(result.structuredContent).toBeDefined()
@@ -683,7 +680,7 @@ describe('Handler structuredContent', () => {
 			findMatches: mock(async () => matches),
 		})
 		let handlers = createToolHandlers(mockClient)
-		let result = await handlers.find_matches({ person_id: 'p2' })
+		let result = await callHandler(handlers, 'find_matches', { person_id: 'p2' })
 
 		expect(result.content[0]?.text).toBe(JSON.stringify(matches, null, 2))
 		expect(result.structuredContent).toBeDefined()
@@ -727,7 +724,7 @@ describe('Handler structuredContent', () => {
 			listPeople: mockListPeople,
 		})
 		let handlers = createToolHandlers(mockClient)
-		let result = await handlers.list_introductions({})
+		let result = await callHandler(handlers, 'list_introductions', {})
 
 		expect(mockListPeople).toHaveBeenCalled()
 		expect(result.structuredContent).toBeDefined()
@@ -762,7 +759,7 @@ describe('Handler structuredContent', () => {
 			getPerson: mockGetPerson,
 		})
 		let handlers = createToolHandlers(mockClient)
-		let result = await handlers.get_introduction({ id: 'i1' })
+		let result = await callHandler(handlers, 'get_introduction', { id: 'i1' })
 
 		expect(mockGetPerson).toHaveBeenCalledTimes(2)
 		expect(result.structuredContent).toBeDefined()
@@ -805,7 +802,7 @@ describe('Handler structuredContent', () => {
 			getPerson: mockGetPerson,
 		})
 		let handlers = createToolHandlers(mockClient)
-		let result = await handlers.list_feedback({ introduction_id: 'i1' })
+		let result = await callHandler(handlers, 'list_feedback', { introduction_id: 'i1' })
 
 		// Should only call getPerson once since both feedback items are from p1
 		expect(mockGetPerson).toHaveBeenCalledTimes(1)
@@ -828,7 +825,7 @@ describe('Handler structuredContent', () => {
 			recordDecision: mockRecord,
 		})
 		let handlers = createToolHandlers(mockClient)
-		let result = await handlers.record_decision({
+		let result = await callHandler(handlers, 'record_decision', {
 			person_id: '00000000-0000-0000-0000-000000000001',
 			candidate_id: '00000000-0000-0000-0000-000000000002',
 			decision: 'declined',
@@ -849,7 +846,7 @@ describe('Handler structuredContent', () => {
 		let mockClient = createMockApiClient()
 		let handlers = createToolHandlers(mockClient)
 		await expect(
-			handlers.record_decision({
+			callHandler(handlers, 'record_decision', {
 				person_id: '00000000-0000-0000-0000-000000000001',
 				candidate_id: '00000000-0000-0000-0000-000000000002',
 				decision: 'maybe',
@@ -874,7 +871,7 @@ describe('Handler structuredContent', () => {
 			listDecisions: mockList,
 		})
 		let handlers = createToolHandlers(mockClient)
-		let result = await handlers.list_decisions({
+		let result = await callHandler(handlers, 'list_decisions', {
 			person_id: '00000000-0000-0000-0000-000000000001',
 		})
 
@@ -900,7 +897,7 @@ describe('Handler structuredContent', () => {
 			}),
 		})
 		let handlers = createToolHandlers(mockClient)
-		let result = await handlers.list_feedback({ introduction_id: 'i1' })
+		let result = await callHandler(handlers, 'list_feedback', { introduction_id: 'i1' })
 
 		// Should still return successfully with fallback to ID
 		expect(result.structuredContent).toBeDefined()

--- a/mcp-server/tests/prompts.test.ts
+++ b/mcp-server/tests/prompts.test.ts
@@ -31,13 +31,16 @@ describe('Prompts', () => {
 			let message = result.messages[0]
 			expect(message).toBeDefined()
 			expect(message?.role).toBe('user')
-			expect(message?.content.type).toBe('text')
-			expect(message?.content.text).toBeDefined()
+			let content = message?.content
+			if (content?.type !== 'text') throw new Error('expected text content')
+			expect(content.text).toBeDefined()
 		})
 
 		test('interview covers key phases', () => {
 			let result = getPrompt('matchmaker_interview')
-			let text = result.messages[0]?.content.text ?? ''
+			let content = result.messages[0]?.content
+			if (content?.type !== 'text') throw new Error('expected text content')
+			let text = content.text
 
 			expect(text).toContain('Phase 1')
 			expect(text).toContain('Phase 13')
@@ -49,7 +52,9 @@ describe('Prompts', () => {
 
 		test('interview addresses matchmaker context', () => {
 			let result = getPrompt('matchmaker_interview')
-			let text = result.messages[0]?.content.text ?? ''
+			let content = result.messages[0]?.content
+			if (content?.type !== 'text') throw new Error('expected text content')
+			let text = content.text
 
 			expect(text).toContain('matchmaker')
 			expect(text).toContain('advocate')

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -15,11 +15,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"outDir": "./dist",
-		"baseUrl": ".",
-		"paths": {
-			"@/*": ["./src/*"]
-		}
+		"outDir": "./dist"
 	},
 	"include": ["src/**/*", "tests/**/*", "**/*.test.ts"],
 	"exclude": ["node_modules", "dist"]

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
 		"test:shared": "cd packages/shared && bun test",
 		"test:backend": "cd backend && bun test",
 		"test:mcp": "cd mcp-server && bun run test",
+		"typecheck": "bun run typecheck:shared && bun run typecheck:backend && bun run typecheck:mcp && bun run typecheck:gateway",
+		"typecheck:shared": "cd packages/shared && bun run typecheck",
+		"typecheck:backend": "cd backend && bun run typecheck",
+		"typecheck:mcp": "cd mcp-server && bun run typecheck",
+		"typecheck:gateway": "cd gateway && bun run typecheck",
 		"get-jwt": "bun run scripts/get-jwt.ts"
 	},
 	"dependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,8 @@
 	"scripts": {
 		"test": "bun test",
 		"test:watch": "bun test --watch",
-		"test:coverage": "bun test --coverage"
+		"test:coverage": "bun test --coverage",
+		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/shared/tests/prompts.test.ts
+++ b/packages/shared/tests/prompts.test.ts
@@ -31,17 +31,16 @@ describe('Prompts', () => {
 			let message = result.messages[0]
 			expect(message).toBeDefined()
 			expect(message?.role).toBe('user')
-			expect(message?.content.type).toBe('text')
 			let content = message?.content
-			if (content?.type === 'text') {
-				expect(content.text).toBeDefined()
-			}
+			if (content?.type !== 'text') throw new Error('expected text content')
+			expect(content.text).toBeDefined()
 		})
 
 		test('interview covers key phases', () => {
 			let result = getPrompt('matchmaker_interview')
 			let content = result.messages[0]?.content
-			let text = content?.type === 'text' ? content.text : ''
+			if (content?.type !== 'text') throw new Error('expected text content')
+			let text = content.text
 
 			expect(text).toContain('Phase 1')
 			expect(text).toContain('Phase 13')
@@ -54,7 +53,8 @@ describe('Prompts', () => {
 		test('interview addresses matchmaker context', () => {
 			let result = getPrompt('matchmaker_interview')
 			let content = result.messages[0]?.content
-			let text = content?.type === 'text' ? content.text : ''
+			if (content?.type !== 'text') throw new Error('expected text content')
+			let text = content.text
 
 			expect(text).toContain('matchmaker')
 			expect(text).toContain('advocate')

--- a/packages/shared/tests/prompts.test.ts
+++ b/packages/shared/tests/prompts.test.ts
@@ -32,12 +32,16 @@ describe('Prompts', () => {
 			expect(message).toBeDefined()
 			expect(message?.role).toBe('user')
 			expect(message?.content.type).toBe('text')
-			expect(message?.content.text).toBeDefined()
+			let content = message?.content
+			if (content?.type === 'text') {
+				expect(content.text).toBeDefined()
+			}
 		})
 
 		test('interview covers key phases', () => {
 			let result = getPrompt('matchmaker_interview')
-			let text = result.messages[0]?.content.text ?? ''
+			let content = result.messages[0]?.content
+			let text = content?.type === 'text' ? content.text : ''
 
 			expect(text).toContain('Phase 1')
 			expect(text).toContain('Phase 13')
@@ -49,7 +53,8 @@ describe('Prompts', () => {
 
 		test('interview addresses matchmaker context', () => {
 			let result = getPrompt('matchmaker_interview')
-			let text = result.messages[0]?.content.text ?? ''
+			let content = result.messages[0]?.content
+			let text = content?.type === 'text' ? content.text : ''
 
 			expect(text).toContain('matchmaker')
 			expect(text).toContain('advocate')

--- a/packages/shared/tests/repositories/person-repository.test.ts
+++ b/packages/shared/tests/repositories/person-repository.test.ts
@@ -20,6 +20,9 @@ function makeStub(): IPersonRepository {
 		async findByMatchmakerId(matchmakerId) {
 			return store.filter((p) => p.matchmakerId === matchmakerId)
 		},
+		async findAllActive() {
+			return store
+		},
 		async create(person) {
 			store.push(person)
 			return person

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -15,11 +15,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"outDir": "./dist",
-		"baseUrl": ".",
-		"paths": {
-			"@/*": ["./src/*"]
-		}
+		"outDir": "./dist"
 	},
 	"include": ["src/**/*", "tests/**/*"],
 	"exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

- Fixes the existing TypeScript errors across all four packages (shared, backend, mcp-server, gateway).
- Adds a `typecheck` script per package and a root aggregator that runs `tsc --noEmit` everywhere.
- Wires a parallel `Typecheck` job into `.github/workflows/test.yml` so this class of regression is caught in CI.

The `src/` fixes worth a closer look:
- `backend/src/schemas/oauth.ts` — Zod 4 dropped the `errorMap` option on `z.literal`; switched to the `message` param. This also restores `response_type`/`code_challenge_method` as plain string literals so `URLSearchParams` ingests them.
- `mcp-server/src/index.ts` — under `noUncheckedIndexedAccess`, `toolHandlers[name]` is `ToolHandler | undefined`. Added an explicit defined-check before invoking, no cast.

The remaining commits resolve test-only errors (unused mock parameters, `await res.json()` body access, optional indexed access, narrowed enum literals) without using `as` casts. Three runtime touches stand out:
- `mcp-server/tests/index.test.ts` — added a `callHandler(handlers, name, args)` helper to route every dispatch through a defined-check, and replaced two ad-hoc partial mocks with `createMockApiClient` so the `IApiClient` surface stays honest.
- prompt content assertions now `throw new Error('expected text content')` if the discriminated content type isn't `'text'` — an honest fail rather than a silent skip.
- `gateway/tests/router/webhook.test.ts` captures the verifyWebhook closure values via an object container so TS doesn't narrow them to `null` literally.

## Test plan
- [x] `bun run typecheck` passes across all packages
- [x] `bun run test` passes (353 backend / 139 mcp-server / 35 gateway tests, plus shared)
- [ ] CI Typecheck job is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)