### PR TITLE
fix(deploy): pin engines.node to >=22 to unblock Railway build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
 	"version": "0.1.0",
 	"private": true,
 	"workspaces": ["backend", "mcp-server", "gateway", "packages/*"],
+	"engines": {
+		"node": ">=22"
+	},
 	"scripts": {
 		"test": "bun run test:shared && bun run test:backend && bun run test:mcp && bun run test:gateway",
 		"test:gateway": "cd gateway && bun test",


### PR DESCRIPTION
## Summary
- Railway/Nixpacks deploy was failing with `error: Node.js 18.x has reached End-Of-Life and has been removed` — Nixpacks defaulted to `nodejs_18` because no Node version was declared anywhere in the repo.
- Adds `engines.node: ">=22"` to root `package.json` so the Node provider resolves a current LTS from nixpkgs instead.
- Runtime is unchanged — backend still runs under Bun (`bun src/index.ts`); this only affects what Nixpacks installs alongside Bun in the build image.

## Test plan
- [ ] Railway build's Nixpacks plan header reads `nodejs_22, bun` (was `nodejs_18, bun`)
- [ ] `nix-env -if .nixpacks/...nix` step succeeds
- [ ] Healthcheck on `/health` passes within 30s after deploy