### PR TITLE
fix(deploy): run backend in production mode with silent bun runner

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
 		"buildCommand": "bun install --frozen-lockfile"
 	},
 	"deploy": {
-		"startCommand": "cd backend && bun run start",
+		"startCommand": "cd backend && NODE_ENV=production bun --silent run start",
 		"healthcheckPath": "/health",
 		"healthcheckTimeout": 30,
 		"restartPolicyType": "ON_FAILURE",


### PR DESCRIPTION
## Summary
- Set `NODE_ENV=production` in Railway's start command so Bun emits `Started server` instead of `Started development server`.
- Pass `--silent` to `bun run` so the `$ bun src/index.ts` command echo no longer hits stderr (Railway was tagging it as `error` severity).

## Test plan
- [ ] Trigger a Railway deploy from this branch.
- [ ] Confirm logs no longer contain `Started development server`.
- [ ] Confirm no log line is severity `error` solely from the start command echo.
- [ ] `/health` continues to return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)