### PR TITLE
fix(mcp): enforce tool schema and stop silently dropping prefs

### DIFF
--- a/backend/src/routes/mcp.ts
+++ b/backend/src/routes/mcp.ts
@@ -205,19 +205,20 @@ export let createMcpRoutes = (supabaseClient: SupabaseClient) => {
 
 		// Handle tool calls by making direct database calls
 		server.setRequestHandler(CallToolRequestSchema, async request => {
-			let { name, arguments: args } = request.params
+			let { name, arguments: rawArgs } = request.params
 
 			try {
 				let toolDef = getToolDefinition(name)
+				let args: Record<string, unknown> | undefined = rawArgs
 				if (toolDef) {
-					let parsed = toolDef.inputSchema.safeParse(args ?? {})
+					let parsed = toolDef.inputSchema.safeParse(rawArgs ?? {})
 					if (!parsed.success) {
 						let detail = parsed.error.issues
 							.map(i => `${i.path.join('.') || '<root>'}: ${i.message}`)
 							.join('; ')
 						throw new Error(`Invalid arguments for ${name}: ${detail}`)
 					}
-					args = parsed.data as typeof args
+					args = parsed.data
 				}
 
 				if (name === 'add_person') {

--- a/backend/src/routes/mcp.ts
+++ b/backend/src/routes/mcp.ts
@@ -11,7 +11,7 @@ import {
 	GetPromptRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import type { SupabaseClient } from '../lib/supabase'
-import { prompts, getPrompt, buildMcpToolList } from '@matchmaker/shared'
+import { prompts, getPrompt, buildMcpToolList, getToolDefinition } from '@matchmaker/shared'
 import { parsePreferences } from '../schemas/preferences'
 import {
 	SupabaseIntroductionRepository,
@@ -208,6 +208,18 @@ export let createMcpRoutes = (supabaseClient: SupabaseClient) => {
 			let { name, arguments: args } = request.params
 
 			try {
+				let toolDef = getToolDefinition(name)
+				if (toolDef) {
+					let parsed = toolDef.inputSchema.safeParse(args ?? {})
+					if (!parsed.success) {
+						let detail = parsed.error.issues
+							.map(i => `${i.path.join('.') || '<root>'}: ${i.message}`)
+							.join('; ')
+						throw new Error(`Invalid arguments for ${name}: ${detail}`)
+					}
+					args = parsed.data as typeof args
+				}
+
 				if (name === 'add_person') {
 					if (
 						!args ||

--- a/backend/src/schemas/preferences.ts
+++ b/backend/src/schemas/preferences.ts
@@ -73,7 +73,10 @@ let stripObjectFields = <T extends z.ZodObject>(
 	section: PreferenceIssue['section'],
 	onInvalid: (issue: PreferenceIssue) => void,
 ): z.infer<T> | undefined => {
-	if (!isRecord(raw)) return undefined
+	if (!isRecord(raw)) {
+		onInvalid({ section, path: [], code: 'invalid_type' })
+		return undefined
+	}
 	let cleaned: Record<string, unknown> = {}
 	for (let [key, fieldSchema] of Object.entries(schema.shape)) {
 		if (!(key in raw)) continue

--- a/backend/src/schemas/preferences.ts
+++ b/backend/src/schemas/preferences.ts
@@ -73,7 +73,13 @@ let stripObjectFields = <T extends z.ZodObject>(
 	section: PreferenceIssue['section'],
 	onInvalid: (issue: PreferenceIssue) => void,
 ): z.infer<T> | undefined => {
-	if (!isRecord(raw)) return undefined
+	if (!isRecord(raw)) {
+		onInvalid({ section, path: [], code: 'invalid_type' })
+		return undefined
+	}
+	let whole = schema.safeParse(raw)
+	if (whole.success) return whole.data
+
 	let cleaned: Record<string, unknown> = {}
 	for (let [key, fieldSchema] of Object.entries(schema.shape)) {
 		if (!(key in raw)) continue
@@ -112,21 +118,30 @@ export let parsePreferences = (
 	}
 
 	if ('dealBreakers' in raw && raw.dealBreakers) {
-		if (Array.isArray(raw.dealBreakers)) {
-			let kept: z.infer<typeof dealBreakersSchema> = []
-			raw.dealBreakers.forEach((entry, index) => {
-				let parsed = dealBreakersSchema.element.safeParse(entry)
-				if (parsed.success) {
-					kept.push(parsed.data)
-				} else {
-					for (let issue of parsed.error.issues) {
-						onInvalid({ section: 'dealBreakers', path: [index, ...issue.path], code: issue.code })
-					}
-				}
-			})
-			if (kept.length > 0) result.dealBreakers = kept
-		} else {
+		if (!Array.isArray(raw.dealBreakers)) {
 			onInvalid({ section: 'dealBreakers', path: [], code: 'invalid_type' })
+		} else {
+			let whole = dealBreakersSchema.safeParse(raw.dealBreakers)
+			if (whole.success) {
+				if (whole.data.length > 0) result.dealBreakers = whole.data
+			} else {
+				let kept: z.infer<typeof dealBreakersSchema> = []
+				raw.dealBreakers.forEach((entry, index) => {
+					let parsed = dealBreakersSchema.element.safeParse(entry)
+					if (parsed.success) {
+						kept.push(parsed.data)
+					} else {
+						for (let issue of parsed.error.issues) {
+							onInvalid({
+								section: 'dealBreakers',
+								path: [index, ...issue.path],
+								code: issue.code,
+							})
+						}
+					}
+				})
+				if (kept.length > 0) result.dealBreakers = kept
+			}
 		}
 	}
 

--- a/backend/src/schemas/preferences.ts
+++ b/backend/src/schemas/preferences.ts
@@ -77,6 +77,9 @@ let stripObjectFields = <T extends z.ZodObject>(
 		onInvalid({ section, path: [], code: 'invalid_type' })
 		return undefined
 	}
+	let whole = schema.safeParse(raw)
+	if (whole.success) return whole.data
+
 	let cleaned: Record<string, unknown> = {}
 	for (let [key, fieldSchema] of Object.entries(schema.shape)) {
 		if (!(key in raw)) continue
@@ -115,21 +118,30 @@ export let parsePreferences = (
 	}
 
 	if ('dealBreakers' in raw && raw.dealBreakers) {
-		if (Array.isArray(raw.dealBreakers)) {
-			let kept: z.infer<typeof dealBreakersSchema> = []
-			raw.dealBreakers.forEach((entry, index) => {
-				let parsed = dealBreakersSchema.element.safeParse(entry)
-				if (parsed.success) {
-					kept.push(parsed.data)
-				} else {
-					for (let issue of parsed.error.issues) {
-						onInvalid({ section: 'dealBreakers', path: [index, ...issue.path], code: issue.code })
-					}
-				}
-			})
-			if (kept.length > 0) result.dealBreakers = kept
-		} else {
+		if (!Array.isArray(raw.dealBreakers)) {
 			onInvalid({ section: 'dealBreakers', path: [], code: 'invalid_type' })
+		} else {
+			let whole = dealBreakersSchema.safeParse(raw.dealBreakers)
+			if (whole.success) {
+				if (whole.data.length > 0) result.dealBreakers = whole.data
+			} else {
+				let kept: z.infer<typeof dealBreakersSchema> = []
+				raw.dealBreakers.forEach((entry, index) => {
+					let parsed = dealBreakersSchema.element.safeParse(entry)
+					if (parsed.success) {
+						kept.push(parsed.data)
+					} else {
+						for (let issue of parsed.error.issues) {
+							onInvalid({
+								section: 'dealBreakers',
+								path: [index, ...issue.path],
+								code: issue.code,
+							})
+						}
+					}
+				})
+				if (kept.length > 0) result.dealBreakers = kept
+			}
 		}
 	}
 

--- a/backend/src/schemas/preferences.ts
+++ b/backend/src/schemas/preferences.ts
@@ -64,18 +64,20 @@ export type ParsePreferencesOptions = {
 	onInvalid?: (issue: PreferenceIssue) => void
 }
 
+let isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === 'object' && value !== null && !Array.isArray(value)
+
 let stripObjectFields = <T extends z.ZodObject>(
 	schema: T,
 	raw: unknown,
 	section: PreferenceIssue['section'],
 	onInvalid: (issue: PreferenceIssue) => void,
 ): z.infer<T> | undefined => {
-	if (!raw || typeof raw !== 'object') return undefined
+	if (!isRecord(raw)) return undefined
 	let cleaned: Record<string, unknown> = {}
 	for (let [key, fieldSchema] of Object.entries(schema.shape)) {
 		if (!(key in raw)) continue
-		let value = (raw as Record<string, unknown>)[key]
-		let parsed = (fieldSchema as z.ZodTypeAny).safeParse(value)
+		let parsed = fieldSchema.safeParse(raw[key])
 		if (parsed.success) {
 			if (parsed.data !== undefined) cleaned[key] = parsed.data
 		} else {
@@ -84,7 +86,9 @@ let stripObjectFields = <T extends z.ZodObject>(
 			}
 		}
 	}
-	return Object.keys(cleaned).length === 0 ? undefined : (cleaned as z.infer<T>)
+	if (Object.keys(cleaned).length === 0) return undefined
+	let reparsed = schema.safeParse(cleaned)
+	return reparsed.success ? reparsed.data : undefined
 }
 
 export let parsePreferences = (

--- a/backend/src/schemas/preferences.ts
+++ b/backend/src/schemas/preferences.ts
@@ -73,13 +73,7 @@ let stripObjectFields = <T extends z.ZodObject>(
 	section: PreferenceIssue['section'],
 	onInvalid: (issue: PreferenceIssue) => void,
 ): z.infer<T> | undefined => {
-	if (!isRecord(raw)) {
-		onInvalid({ section, path: [], code: 'invalid_type' })
-		return undefined
-	}
-	let whole = schema.safeParse(raw)
-	if (whole.success) return whole.data
-
+	if (!isRecord(raw)) return undefined
 	let cleaned: Record<string, unknown> = {}
 	for (let [key, fieldSchema] of Object.entries(schema.shape)) {
 		if (!(key in raw)) continue
@@ -118,30 +112,21 @@ export let parsePreferences = (
 	}
 
 	if ('dealBreakers' in raw && raw.dealBreakers) {
-		if (!Array.isArray(raw.dealBreakers)) {
-			onInvalid({ section: 'dealBreakers', path: [], code: 'invalid_type' })
-		} else {
-			let whole = dealBreakersSchema.safeParse(raw.dealBreakers)
-			if (whole.success) {
-				if (whole.data.length > 0) result.dealBreakers = whole.data
-			} else {
-				let kept: z.infer<typeof dealBreakersSchema> = []
-				raw.dealBreakers.forEach((entry, index) => {
-					let parsed = dealBreakersSchema.element.safeParse(entry)
-					if (parsed.success) {
-						kept.push(parsed.data)
-					} else {
-						for (let issue of parsed.error.issues) {
-							onInvalid({
-								section: 'dealBreakers',
-								path: [index, ...issue.path],
-								code: issue.code,
-							})
-						}
+		if (Array.isArray(raw.dealBreakers)) {
+			let kept: z.infer<typeof dealBreakersSchema> = []
+			raw.dealBreakers.forEach((entry, index) => {
+				let parsed = dealBreakersSchema.element.safeParse(entry)
+				if (parsed.success) {
+					kept.push(parsed.data)
+				} else {
+					for (let issue of parsed.error.issues) {
+						onInvalid({ section: 'dealBreakers', path: [index, ...issue.path], code: issue.code })
 					}
-				})
-				if (kept.length > 0) result.dealBreakers = kept
-			}
+				}
+			})
+			if (kept.length > 0) result.dealBreakers = kept
+		} else {
+			onInvalid({ section: 'dealBreakers', path: [], code: 'invalid_type' })
 		}
 	}
 

--- a/backend/src/schemas/preferences.ts
+++ b/backend/src/schemas/preferences.ts
@@ -54,35 +54,75 @@ export let structuredPreferencesSchema = z.object({
 
 export type StructuredPreferences = z.infer<typeof structuredPreferencesSchema>
 
-export let parsePreferences = (raw: Record<string, unknown> | null): StructuredPreferences => {
+export type PreferenceIssue = {
+	section: 'aboutMe' | 'lookingFor' | 'dealBreakers'
+	path: PropertyKey[]
+	code: string
+}
+
+export type ParsePreferencesOptions = {
+	onInvalid?: (issue: PreferenceIssue) => void
+}
+
+let stripObjectFields = <T extends z.ZodObject>(
+	schema: T,
+	raw: unknown,
+	section: PreferenceIssue['section'],
+	onInvalid: (issue: PreferenceIssue) => void,
+): z.infer<T> | undefined => {
+	if (!raw || typeof raw !== 'object') return undefined
+	let cleaned: Record<string, unknown> = {}
+	for (let [key, fieldSchema] of Object.entries(schema.shape)) {
+		if (!(key in raw)) continue
+		let value = (raw as Record<string, unknown>)[key]
+		let parsed = (fieldSchema as z.ZodTypeAny).safeParse(value)
+		if (parsed.success) {
+			if (parsed.data !== undefined) cleaned[key] = parsed.data
+		} else {
+			for (let issue of parsed.error.issues) {
+				onInvalid({ section, path: [key, ...issue.path], code: issue.code })
+			}
+		}
+	}
+	return Object.keys(cleaned).length === 0 ? undefined : (cleaned as z.infer<T>)
+}
+
+export let parsePreferences = (
+	raw: Record<string, unknown> | null,
+	options: ParsePreferencesOptions = {},
+): StructuredPreferences => {
 	if (!raw) return {}
+
+	let onInvalid = options.onInvalid ?? (() => {})
 
 	let result: StructuredPreferences = {}
 
 	if ('aboutMe' in raw && raw.aboutMe) {
-		let parsed = aboutMeSchema.safeParse(raw.aboutMe)
-		if (parsed.success) {
-			result.aboutMe = parsed.data
-		} else {
-			console.warn('parsePreferences: invalid aboutMe dropped', parsed.error.issues)
-		}
+		let cleaned = stripObjectFields(aboutMeSchema, raw.aboutMe, 'aboutMe', onInvalid)
+		if (cleaned) result.aboutMe = cleaned
 	}
 
 	if ('lookingFor' in raw && raw.lookingFor) {
-		let parsed = lookingForSchema.safeParse(raw.lookingFor)
-		if (parsed.success) {
-			result.lookingFor = parsed.data
-		} else {
-			console.warn('parsePreferences: invalid lookingFor dropped', parsed.error.issues)
-		}
+		let cleaned = stripObjectFields(lookingForSchema, raw.lookingFor, 'lookingFor', onInvalid)
+		if (cleaned) result.lookingFor = cleaned
 	}
 
 	if ('dealBreakers' in raw && raw.dealBreakers) {
-		let parsed = dealBreakersSchema.safeParse(raw.dealBreakers)
-		if (parsed.success) {
-			result.dealBreakers = parsed.data
+		if (Array.isArray(raw.dealBreakers)) {
+			let kept: z.infer<typeof dealBreakersSchema> = []
+			raw.dealBreakers.forEach((entry, index) => {
+				let parsed = dealBreakersSchema.element.safeParse(entry)
+				if (parsed.success) {
+					kept.push(parsed.data)
+				} else {
+					for (let issue of parsed.error.issues) {
+						onInvalid({ section: 'dealBreakers', path: [index, ...issue.path], code: issue.code })
+					}
+				}
+			})
+			if (kept.length > 0) result.dealBreakers = kept
 		} else {
-			console.warn('parsePreferences: invalid dealBreakers dropped', parsed.error.issues)
+			onInvalid({ section: 'dealBreakers', path: [], code: 'invalid_type' })
 		}
 	}
 

--- a/backend/tests/routes/mcp-preferences.test.ts
+++ b/backend/tests/routes/mcp-preferences.test.ts
@@ -130,7 +130,7 @@ describe('update_person preferences validation', () => {
 		expect((parsed.aboutMe as Record<string, unknown>).height).toBe(180)
 	})
 
-	test('invalid preferences sub-section gets dropped', async () => {
+	test('invalid preferences enum value rejects with a tool error and does not update', async () => {
 		let prefs = {
 			aboutMe: { build: 'INVALID_ENUM_VALUE' },
 			lookingFor: { wantsChildren: true },
@@ -141,12 +141,24 @@ describe('update_person preferences validation', () => {
 			preferences: prefs,
 		})
 
-		expect(result.isError).toBeFalsy()
-		let updated = lastUpdate as Record<string, unknown>
-		let parsed = updated.preferences as Record<string, unknown>
-		// invalid aboutMe should be dropped, valid lookingFor kept
-		expect(parsed.aboutMe).toBeUndefined()
-		expect(parsed.lookingFor).toEqual({ wantsChildren: true })
+		expect(result.isError).toBe(true)
+		expect(result.content[0]?.text).toMatch(/aboutMe.*build/i)
+		expect(lastUpdate).toBeUndefined()
+	})
+
+	test('invalid preferences type (religionRequired boolean) rejects with a tool error', async () => {
+		let prefs = {
+			lookingFor: { religionRequired: true },
+		}
+
+		let result = await callTool(app, 'update_person', {
+			id: 'person-1',
+			preferences: prefs,
+		})
+
+		expect(result.isError).toBe(true)
+		expect(result.content[0]?.text).toMatch(/religionRequired/)
+		expect(lastUpdate).toBeUndefined()
 	})
 
 	test('null preferences skip validation', async () => {

--- a/backend/tests/schemas/mcpToolsPreferencesRoundtrip.test.ts
+++ b/backend/tests/schemas/mcpToolsPreferencesRoundtrip.test.ts
@@ -20,10 +20,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+function unwrapNullable(schema: Record<string, unknown>): Record<string, unknown> {
+	let any = schema.anyOf
+	if (!Array.isArray(any)) return schema
+	let nonNull = any.find((s): s is Record<string, unknown> => isRecord(s) && s.type !== 'null')
+	return nonNull ?? schema
+}
+
 function getRecord(parent: Record<string, unknown>, key: string): Record<string, unknown> {
 	let value = parent[key]
 	if (!isRecord(value)) throw new Error(`expected object at ${key}, got ${typeof value}`)
-	return value
+	return unwrapNullable(value)
 }
 
 function getStringEnum(schema: Record<string, unknown>): string[] {

--- a/backend/tests/schemas/preferences.test.ts
+++ b/backend/tests/schemas/preferences.test.ts
@@ -235,6 +235,33 @@ describe('parsePreferences', () => {
 		])
 	})
 
+	test('should not call per-field safeParse when whole section is valid (fast-path)', () => {
+		let aboutMeCallCount = 0
+		let originalParse = aboutMeSchema.safeParse.bind(aboutMeSchema)
+		let heightSchema = aboutMeSchema.shape.height
+		let originalHeightParse = heightSchema.safeParse.bind(heightSchema)
+		let heightCallCount = 0
+		aboutMeSchema.safeParse = (...args: Parameters<typeof originalParse>) => {
+			aboutMeCallCount++
+			return originalParse(...args)
+		}
+		heightSchema.safeParse = (...args: Parameters<typeof originalHeightParse>) => {
+			heightCallCount++
+			return originalHeightParse(...args)
+		}
+		try {
+			let result = parsePreferences({
+				aboutMe: { height: 175, build: 'athletic', fitnessLevel: 'active' },
+			})
+			expect(result.aboutMe).toEqual({ height: 175, build: 'athletic', fitnessLevel: 'active' })
+			expect(aboutMeCallCount).toBe(1)
+			expect(heightCallCount).toBe(0)
+		} finally {
+			aboutMeSchema.safeParse = originalParse
+			heightSchema.safeParse = originalHeightParse
+		}
+	})
+
 	test('should report invalid_type via onInvalid when section is not an object', () => {
 		let issues: Array<{ section: string; path: PropertyKey[]; code: string }> = []
 		let result = parsePreferences(

--- a/backend/tests/schemas/preferences.test.ts
+++ b/backend/tests/schemas/preferences.test.ts
@@ -235,47 +235,6 @@ describe('parsePreferences', () => {
 		])
 	})
 
-	test('should report invalid_type via onInvalid when section is not an object', () => {
-		let issues: Array<{ section: string; path: PropertyKey[]; code: string }> = []
-		let result = parsePreferences(
-			{ aboutMe: 'oops', lookingFor: 123 },
-			{ onInvalid: issue => issues.push(issue) },
-		)
-		expect(result.aboutMe).toBeUndefined()
-		expect(result.lookingFor).toBeUndefined()
-		expect(issues).toEqual([
-			{ section: 'aboutMe', path: [], code: 'invalid_type' },
-			{ section: 'lookingFor', path: [], code: 'invalid_type' },
-		])
-	})
-
-	test('should not call per-field safeParse when whole section is valid (fast-path)', () => {
-		let aboutMeCallCount = 0
-		let originalParse = aboutMeSchema.safeParse.bind(aboutMeSchema)
-		let heightSchema = aboutMeSchema.shape.height
-		let originalHeightParse = heightSchema.safeParse.bind(heightSchema)
-		let heightCallCount = 0
-		aboutMeSchema.safeParse = (...args: Parameters<typeof originalParse>) => {
-			aboutMeCallCount++
-			return originalParse(...args)
-		}
-		heightSchema.safeParse = (...args: Parameters<typeof originalHeightParse>) => {
-			heightCallCount++
-			return originalHeightParse(...args)
-		}
-		try {
-			let result = parsePreferences({
-				aboutMe: { height: 175, build: 'athletic', fitnessLevel: 'active' },
-			})
-			expect(result.aboutMe).toEqual({ height: 175, build: 'athletic', fitnessLevel: 'active' })
-			expect(aboutMeCallCount).toBe(1)
-			expect(heightCallCount).toBe(0)
-		} finally {
-			aboutMeSchema.safeParse = originalParse
-			heightSchema.safeParse = originalHeightParse
-		}
-	})
-
 	test('should return empty object for null input', () => {
 		let result = parsePreferences(null)
 		expect(result).toEqual({})

--- a/backend/tests/schemas/preferences.test.ts
+++ b/backend/tests/schemas/preferences.test.ts
@@ -168,10 +168,71 @@ describe('parsePreferences', () => {
 		expect(result.dealBreakers).toEqual(['isSmoker'])
 	})
 
-	test('should drop invalid aboutMe section', () => {
+	test('should drop invalid aboutMe section when no valid siblings remain', () => {
 		let raw = { aboutMe: { build: 'gigantic' } }
 		let result = parsePreferences(raw)
 		expect(result.aboutMe).toBeUndefined()
+	})
+
+	test('should drop only invalid fields and keep valid siblings in aboutMe', () => {
+		let raw = {
+			aboutMe: { build: 'gigantic', height: 175, fitnessLevel: 'active' },
+		}
+		let result = parsePreferences(raw)
+		expect(result.aboutMe).toEqual({ height: 175, fitnessLevel: 'active' })
+	})
+
+	test('should drop only invalid fields and keep valid siblings in lookingFor', () => {
+		let raw = {
+			lookingFor: { religionRequired: true, wantsChildren: true, fitnessPreference: 'any' },
+		}
+		let result = parsePreferences(raw)
+		expect(result.lookingFor).toEqual({ wantsChildren: true, fitnessPreference: 'any' })
+	})
+
+	test('should drop only invalid entries and keep valid ones in dealBreakers', () => {
+		let raw = { dealBreakers: ['isSmoker', 'not_real', 'hasChildren'] }
+		let result = parsePreferences(raw)
+		expect(result.dealBreakers).toEqual(['isSmoker', 'hasChildren'])
+	})
+
+	test('should drop dealBreakers entirely when all entries are invalid', () => {
+		let raw = { dealBreakers: ['nope', 'also_nope'] }
+		let result = parsePreferences(raw)
+		expect(result.dealBreakers).toBeUndefined()
+	})
+
+	test('should not log per-field issues by default (silent read-path normalizer)', () => {
+		let original = console.warn
+		let warnings: unknown[][] = []
+		console.warn = (...args: unknown[]) => warnings.push(args)
+		try {
+			parsePreferences({
+				aboutMe: { build: 'gigantic', height: 175 },
+				lookingFor: { religionRequired: true },
+				dealBreakers: ['nope', 'isSmoker'],
+			})
+		} finally {
+			console.warn = original
+		}
+		expect(warnings).toEqual([])
+	})
+
+	test('should invoke onInvalid callback once per invalid field when provided', () => {
+		let issues: Array<{ section: string; path: PropertyKey[]; code: string }> = []
+		parsePreferences(
+			{
+				aboutMe: { build: 'gigantic', height: 175 },
+				lookingFor: { religionRequired: true },
+				dealBreakers: ['nope', 'isSmoker'],
+			},
+			{ onInvalid: issue => issues.push(issue) },
+		)
+		expect(issues.map(i => `${i.section}.${i.path.join('.')}`)).toEqual([
+			'aboutMe.build',
+			'lookingFor.religionRequired',
+			'dealBreakers.0',
+		])
 	})
 
 	test('should return empty object for null input', () => {
@@ -184,7 +245,7 @@ describe('parsePreferences', () => {
 		expect(result).toEqual({})
 	})
 
-	test('should keep valid sections and drop invalid ones', () => {
+	test('should keep valid sections and drop fully-invalid ones', () => {
 		let raw = {
 			aboutMe: { build: 'INVALID' },
 			lookingFor: { wantsChildren: true },

--- a/backend/tests/schemas/preferences.test.ts
+++ b/backend/tests/schemas/preferences.test.ts
@@ -235,6 +235,47 @@ describe('parsePreferences', () => {
 		])
 	})
 
+	test('should report invalid_type via onInvalid when section is not an object', () => {
+		let issues: Array<{ section: string; path: PropertyKey[]; code: string }> = []
+		let result = parsePreferences(
+			{ aboutMe: 'oops', lookingFor: 123 },
+			{ onInvalid: issue => issues.push(issue) },
+		)
+		expect(result.aboutMe).toBeUndefined()
+		expect(result.lookingFor).toBeUndefined()
+		expect(issues).toEqual([
+			{ section: 'aboutMe', path: [], code: 'invalid_type' },
+			{ section: 'lookingFor', path: [], code: 'invalid_type' },
+		])
+	})
+
+	test('should not call per-field safeParse when whole section is valid (fast-path)', () => {
+		let aboutMeCallCount = 0
+		let originalParse = aboutMeSchema.safeParse.bind(aboutMeSchema)
+		let heightSchema = aboutMeSchema.shape.height
+		let originalHeightParse = heightSchema.safeParse.bind(heightSchema)
+		let heightCallCount = 0
+		aboutMeSchema.safeParse = (...args: Parameters<typeof originalParse>) => {
+			aboutMeCallCount++
+			return originalParse(...args)
+		}
+		heightSchema.safeParse = (...args: Parameters<typeof originalHeightParse>) => {
+			heightCallCount++
+			return originalHeightParse(...args)
+		}
+		try {
+			let result = parsePreferences({
+				aboutMe: { height: 175, build: 'athletic', fitnessLevel: 'active' },
+			})
+			expect(result.aboutMe).toEqual({ height: 175, build: 'athletic', fitnessLevel: 'active' })
+			expect(aboutMeCallCount).toBe(1)
+			expect(heightCallCount).toBe(0)
+		} finally {
+			aboutMeSchema.safeParse = originalParse
+			heightSchema.safeParse = originalHeightParse
+		}
+	})
+
 	test('should return empty object for null input', () => {
 		let result = parsePreferences(null)
 		expect(result).toEqual({})

--- a/backend/tests/schemas/preferences.test.ts
+++ b/backend/tests/schemas/preferences.test.ts
@@ -235,6 +235,20 @@ describe('parsePreferences', () => {
 		])
 	})
 
+	test('should report invalid_type via onInvalid when section is not an object', () => {
+		let issues: Array<{ section: string; path: PropertyKey[]; code: string }> = []
+		let result = parsePreferences(
+			{ aboutMe: 'oops', lookingFor: 123 },
+			{ onInvalid: issue => issues.push(issue) },
+		)
+		expect(result.aboutMe).toBeUndefined()
+		expect(result.lookingFor).toBeUndefined()
+		expect(issues).toEqual([
+			{ section: 'aboutMe', path: [], code: 'invalid_type' },
+			{ section: 'lookingFor', path: [], code: 'invalid_type' },
+		])
+	})
+
 	test('should return empty object for null input', () => {
 		let result = parsePreferences(null)
 		expect(result).toEqual({})

--- a/packages/shared/src/mcp/tool-registry.ts
+++ b/packages/shared/src/mcp/tool-registry.ts
@@ -83,8 +83,11 @@ let updatePerson: ToolDefinition = {
 		location: z.string().optional().describe('Person location'),
 		gender: z.string().optional().describe('Person gender'),
 		preferences: preferencesShape
+			.nullable()
 			.optional()
-			.describe('Structured preferences with aboutMe, lookingFor, and dealBreakers sections'),
+			.describe(
+				'Structured preferences with aboutMe, lookingFor, and dealBreakers sections. Pass null to clear.',
+			),
 		personality: z
 			.record(z.string(), z.unknown())
 			.optional()


### PR DESCRIPTION
## Summary

Logs from prod (Railway) showed 525 `parsePreferences: invalid … dropped` errors in ~3 minutes, blowing through Railway's 500 logs/sec ceiling **twice** (547 + 544 messages dropped) during normal `find_matches` traffic. Two underlying bugs:

1. **MCP handler was decorative-only.** `update_person`'s registered Zod schema (incl. `religionRequired: z.string().nullable().optional()`) was never enforced — `args` was cast to `Record<string, unknown>` and forwarded. LLM-generated payloads like `religionRequired: true` returned HTTP 200 with a silently truncated record.
2. **`parsePreferences` was a guillotine.** A single bad field would drop the entire `aboutMe` / `lookingFor` sub-object, plus emit a multi-line `console.warn(label, issues)` that Node pretty-prints across ~20 lines per call. Multiplied by N candidates inside `findMatches`, that's the log explosion.

## Changes (two TDD commits)

- `refactor(prefs)`: `parsePreferences` now strips invalid fields per-field and keeps valid siblings. `dealBreakers` array entries are filtered individually. The chatty `console.warn` is gone — callers that want issue details can pass `onInvalid` and receive a structured `PreferenceIssue` per bad field.
- `fix(mcp)`: every `tools/call` is now parsed against `getToolDefinition(name).inputSchema` before dispatch. Bad payloads return an MCP tool error (`isError: true`) with the offending paths so the model can self-correct on retry. `update_person.preferences` is now `.nullable().optional()` so callers can intentionally clear the field.

## Test plan

- [x] `bun test` (backend, mcp-server, gateway, shared) — 534 pass / 0 fail
- [x] `bun run typecheck` across all four packages
- [x] Red→green TDD for both units: failing tests asserting per-field-strip behavior in `preferences.test.ts`, then failing tests asserting `isError: true` for `update_person` with bad enum / boolean `religionRequired` in `mcp-preferences.test.ts`
- [ ] Confirm in Railway after deploy that `parsePreferences:` warnings disappear from the read path and that bad MCP `update_person` calls now return `isError: true` instead of corrupting state

🤖 Generated with [Claude Code](https://claude.com/claude-code)