### PR TITLE
fix(mcp): allow get_person to read across matchmakers

### DIFF
--- a/backend/src/routes/mcp.ts
+++ b/backend/src/routes/mcp.ts
@@ -257,13 +257,15 @@ export let createMcpRoutes = (supabaseClient: SupabaseClient) => {
 					if (!args || typeof args !== 'object' || !('id' in args) || typeof args.id !== 'string') {
 						throw new Error('Invalid arguments: id is required and must be a string')
 					}
+					// Mirrors find_matches' cross-matchmaker pool: any candidate that
+					// can surface as a match must also be inspectable by id.
 					let { data, error } = await supabaseClient
 						.from('people')
 						.select('*')
 						.eq('id', args.id)
-						.eq('matchmaker_id', userId)
-						.single()
+						.maybeSingle()
 					if (error) throw new Error(error.message)
+					if (!data) throw new Error('Person not found')
 					return {
 						content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
 					}

--- a/backend/src/routes/mcp.ts
+++ b/backend/src/routes/mcp.ts
@@ -257,12 +257,14 @@ export let createMcpRoutes = (supabaseClient: SupabaseClient) => {
 					if (!args || typeof args !== 'object' || !('id' in args) || typeof args.id !== 'string') {
 						throw new Error('Invalid arguments: id is required and must be a string')
 					}
-					// Mirrors find_matches' cross-matchmaker pool: any candidate that
-					// can surface as a match must also be inspectable by id.
+					// Mirrors find_matches' cross-matchmaker pool (active people only):
+					// any active candidate that can surface as a match must also be
+					// inspectable by id.
 					let { data, error } = await supabaseClient
 						.from('people')
 						.select('*')
 						.eq('id', args.id)
+						.eq('active', true)
 						.maybeSingle()
 					if (error) throw new Error(error.message)
 					if (!data) throw new Error('Person not found')

--- a/backend/tests/routes/mcp.test.ts
+++ b/backend/tests/routes/mcp.test.ts
@@ -659,7 +659,9 @@ describe('MCP Routes', () => {
 				from: mock(() => ({
 					select: mock(() => ({
 						eq: mock(() => ({
-							maybeSingle: mock(async () => ({ data: liam, error: null })),
+							eq: mock(() => ({
+								maybeSingle: mock(async () => ({ data: liam, error: null })),
+							})),
 						})),
 					})),
 				})),
@@ -695,6 +697,60 @@ describe('MCP Routes', () => {
 			expect(parsed.matchmaker_id).toBe('other-matchmaker')
 		})
 
+		test('get_person treats inactive (soft-deleted) people as not found', async () => {
+			let inactiveClient = createMockSupabaseClient({
+				auth: {
+					getUser: mock(async () => ({
+						data: { user: { id: 'user-123' } },
+						error: null,
+					})),
+				},
+				from: mock(() => ({
+					select: mock(() => ({
+						eq: mock((column: string) => {
+							// Second .eq is the active filter — return no row when active=true
+							// is required, simulating an inactive match.
+							if (column === 'active') {
+								return {
+									maybeSingle: mock(async () => ({ data: null, error: null })),
+								}
+							}
+							return {
+								eq: mock(() => ({
+									maybeSingle: mock(async () => ({ data: null, error: null })),
+								})),
+							}
+						}),
+					})),
+				})),
+			})
+
+			let inactiveApp = new Hono()
+			inactiveApp.route('/mcp', createMcpRoutes(inactiveClient))
+
+			let req = new Request('http://localhost/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					Authorization: 'Bearer valid-token',
+				},
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'tools/call',
+					params: { name: 'get_person', arguments: { id: 'inactive-id' } },
+					id: 2,
+				}),
+			})
+
+			let res = await inactiveApp.fetch(req)
+			expect(res.status).toBe(200)
+
+			let body = await jsonBody(res)
+			expect(body.result?.isError).toBe(true)
+			expect(body.result?.content?.[0]?.text).toBe('Error: Person not found')
+		})
+
 		test('get_person returns clean not-found error when id is unknown', async () => {
 			let notFoundClient = createMockSupabaseClient({
 				auth: {
@@ -706,7 +762,9 @@ describe('MCP Routes', () => {
 				from: mock(() => ({
 					select: mock(() => ({
 						eq: mock(() => ({
-							maybeSingle: mock(async () => ({ data: null, error: null })),
+							eq: mock(() => ({
+								maybeSingle: mock(async () => ({ data: null, error: null })),
+							})),
 						})),
 					})),
 				})),
@@ -750,9 +808,11 @@ describe('MCP Routes', () => {
 				from: mock(() => ({
 					select: mock(() => ({
 						eq: mock(() => ({
-							maybeSingle: mock(async () => ({
-								data: null,
-								error: { message: 'Database error', code: 'DB001' },
+							eq: mock(() => ({
+								maybeSingle: mock(async () => ({
+									data: null,
+									error: { message: 'Database error', code: 'DB001' },
+								})),
 							})),
 						})),
 					})),

--- a/backend/tests/routes/mcp.test.ts
+++ b/backend/tests/routes/mcp.test.ts
@@ -642,6 +642,102 @@ describe('MCP Routes', () => {
 			expect(body.result?.content?.[0]?.text).toBe('Error: Introduction not found')
 		})
 
+		test('get_person reads people across matchmakers (find_matches surfaces them)', async () => {
+			let liam = {
+				id: 'liam-id',
+				name: 'Liam',
+				matchmaker_id: 'other-matchmaker',
+				active: true,
+			}
+			let crossMatchmakerClient = createMockSupabaseClient({
+				auth: {
+					getUser: mock(async () => ({
+						data: { user: { id: 'user-123' } },
+						error: null,
+					})),
+				},
+				from: mock(() => ({
+					select: mock(() => ({
+						eq: mock(() => ({
+							maybeSingle: mock(async () => ({ data: liam, error: null })),
+						})),
+					})),
+				})),
+			})
+
+			let crossApp = new Hono()
+			crossApp.route('/mcp', createMcpRoutes(crossMatchmakerClient))
+
+			let req = new Request('http://localhost/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					Authorization: 'Bearer valid-token',
+				},
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'tools/call',
+					params: { name: 'get_person', arguments: { id: liam.id } },
+					id: 2,
+				}),
+			})
+
+			let res = await crossApp.fetch(req)
+			expect(res.status).toBe(200)
+
+			let body = await jsonBody(res)
+			expect(body.result?.isError).toBeFalsy()
+			let textContent = body.result?.content?.find(c => c.type === 'text')
+			expect(textContent?.text).toBeDefined()
+			let parsed = JSON.parse(textContent?.text ?? '{}')
+			expect(parsed.id).toBe(liam.id)
+			expect(parsed.matchmaker_id).toBe('other-matchmaker')
+		})
+
+		test('get_person returns clean not-found error when id is unknown', async () => {
+			let notFoundClient = createMockSupabaseClient({
+				auth: {
+					getUser: mock(async () => ({
+						data: { user: { id: 'user-123' } },
+						error: null,
+					})),
+				},
+				from: mock(() => ({
+					select: mock(() => ({
+						eq: mock(() => ({
+							maybeSingle: mock(async () => ({ data: null, error: null })),
+						})),
+					})),
+				})),
+			})
+
+			let notFoundApp = new Hono()
+			notFoundApp.route('/mcp', createMcpRoutes(notFoundClient))
+
+			let req = new Request('http://localhost/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					Authorization: 'Bearer valid-token',
+				},
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					method: 'tools/call',
+					params: { name: 'get_person', arguments: { id: 'unknown-id' } },
+					id: 2,
+				}),
+			})
+
+			let res = await notFoundApp.fetch(req)
+			expect(res.status).toBe(200)
+
+			let body = await jsonBody(res)
+			expect(body.result?.isError).toBe(true)
+			expect(body.result?.content?.[0]?.text).toBe('Error: Person not found')
+		})
+
 		test('MCP tool error responses follow specification format', async () => {
 			// Mock Supabase to return an error for a tool call
 			let errorMockSupabaseClient = createMockSupabaseClient({
@@ -654,11 +750,9 @@ describe('MCP Routes', () => {
 				from: mock(() => ({
 					select: mock(() => ({
 						eq: mock(() => ({
-							eq: mock(() => ({
-								single: mock(async () => ({
-									data: null,
-									error: { message: 'Person not found', code: 'PGRST116' },
-								})),
+							maybeSingle: mock(async () => ({
+								data: null,
+								error: { message: 'Database error', code: 'DB001' },
 							})),
 						})),
 					})),


### PR DESCRIPTION
## Summary

- The MCP `get_person` handler scoped its query to the caller's `matchmaker_id` and used `.single()`. Any candidate surfaced by `find_matches` (which searches the cross-matchmaker pool, see `services/matchFinder.ts`) failed with PostgREST's `PGRST116` message: `Error: Cannot coerce the result to a single JSON object` — making it impossible to vet candidates owned by other matchmakers.
- Dropped the `matchmaker_id` filter so `get_person` mirrors the visibility already exposed by `find_matches`, switched `.single()` → `.maybeSingle()`, and surface a clear `Error: Person not found` when no row matches.
- Replaces the cryptic PostgREST message with an actionable one and unblocks the cross-matchmaker introduction workflow.

## Test plan

- [x] `bun test backend/tests/routes/mcp.test.ts` — 25 pass
- [x] `bun test backend` — 364 pass
- [x] `cd backend && bun run typecheck` — clean
- [x] New test: `get_person` returns rows owned by a different matchmaker
- [x] New test: `get_person` returns `Error: Person not found` for unknown ids
- [x] Updated existing tool-error-format test to use the new query chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)