### PR TITLE
ci(railway): skip devDeps so better-sqlite3 doesn't break Node 24 builds

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,4 @@
+providers = ["node", "bun"]
+
+[phases.install]
+cmds = ["bun install --production --frozen-lockfile"]

--- a/railway.json
+++ b/railway.json
@@ -2,7 +2,7 @@
 	"$schema": "https://railway.app/railway.schema.json",
 	"build": {
 		"builder": "NIXPACKS",
-		"buildCommand": "bun install --frozen-lockfile"
+		"buildCommand": "bun install --production --frozen-lockfile"
 	},
 	"deploy": {
 		"startCommand": "cd backend && NODE_ENV=production bun --silent run start",


### PR DESCRIPTION
## Summary
- Railway nixpacks deploy was failing in the install phase: `evalite` (gateway devDep) pulls `better-sqlite3@11.10.0`, which has no prebuild for Node 24 and falls through to `node-gyp` — not present in the nixpacks image — exiting 127.
- Add `nixpacks.toml` to override the install phase with `bun install --production --frozen-lockfile`, and match `railway.json`'s `buildCommand` so devDeps stay out of the prod image.
- Backend's runtime deps are all under `dependencies`; nothing in the start path (`cd backend && bun src/index.ts`) needs the dev tooling.

## Test plan
- [ ] Trigger a Railway deploy from this branch and confirm the install phase no longer attempts to compile `better-sqlite3`.
- [ ] Confirm the service boots (`/health` returns 200) — backend start command unchanged.
- [ ] Spot-check that local `bun install` still works (no flag changes locally; only Railway's install/build phases changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)