### PR TITLE
feat(gateway): add user provider mapping service with auto-provisioning

### DIFF
--- a/gateway/src/services/index.ts
+++ b/gateway/src/services/index.ts
@@ -1,2 +1,8 @@
 export { HandleInboundMessage } from './handle-inbound-message'
 export { InboundParseError } from './errors'
+export {
+	createUserMappingService,
+	DuplicateMappingError,
+	type UserMappingDb,
+	type UserMappingService,
+} from './user-mapping'

--- a/gateway/src/services/user-mapping.ts
+++ b/gateway/src/services/user-mapping.ts
@@ -1,0 +1,59 @@
+export interface UserMappingDb {
+	findUserId(provider: string, senderId: string): Promise<string | null>
+	createUser(seed: { provider: string; senderId: string }): Promise<string>
+	insertMapping(provider: string, senderId: string, userId: string): Promise<void>
+}
+
+export class DuplicateMappingError extends Error {
+	constructor(
+		public readonly provider: string,
+		public readonly senderId: string,
+	) {
+		super(`Mapping already exists for provider="${provider}" senderId="${senderId}"`)
+		this.name = 'DuplicateMappingError'
+	}
+}
+
+export interface UserMappingService {
+	resolveOrCreate(provider: string, senderId: string): Promise<string>
+}
+
+let PHONE_PROVIDERS = ['whatsapp', 'sms'] as const
+
+function phoneSiblingsOf(provider: string): string[] {
+	if (!PHONE_PROVIDERS.includes(provider as (typeof PHONE_PROVIDERS)[number])) {
+		return []
+	}
+	return PHONE_PROVIDERS.filter(p => p !== provider)
+}
+
+export function createUserMappingService(options: { db: UserMappingDb }): UserMappingService {
+	let { db } = options
+
+	return {
+		async resolveOrCreate(provider, senderId) {
+			let existing = await db.findUserId(provider, senderId)
+			if (existing) return existing
+
+			for (let sibling of phoneSiblingsOf(provider)) {
+				let viaSibling = await db.findUserId(sibling, senderId)
+				if (viaSibling) {
+					await db.insertMapping(provider, senderId, viaSibling)
+					return viaSibling
+				}
+			}
+
+			let userId = await db.createUser({ provider, senderId })
+			try {
+				await db.insertMapping(provider, senderId, userId)
+			} catch (err) {
+				if (err instanceof DuplicateMappingError) {
+					let winner = await db.findUserId(provider, senderId)
+					if (winner) return winner
+				}
+				throw err
+			}
+			return userId
+		},
+	}
+}

--- a/gateway/src/services/user-mapping.ts
+++ b/gateway/src/services/user-mapping.ts
@@ -19,7 +19,7 @@ export interface UserMappingService {
 	resolveOrCreate(provider: string, senderId: string): Promise<string>
 }
 
-let PHONE_PROVIDERS = ['whatsapp', 'sms'] as const
+const PHONE_PROVIDERS = ['whatsapp', 'sms'] as const
 
 function phoneSiblingsOf(provider: string): string[] {
 	if (!PHONE_PROVIDERS.includes(provider as (typeof PHONE_PROVIDERS)[number])) {

--- a/gateway/src/services/user-mapping.ts
+++ b/gateway/src/services/user-mapping.ts
@@ -38,7 +38,15 @@ export function createUserMappingService(options: { db: UserMappingDb }): UserMa
 			for (let sibling of phoneSiblingsOf(provider)) {
 				let viaSibling = await db.findUserId(sibling, senderId)
 				if (viaSibling) {
-					await db.insertMapping(provider, senderId, viaSibling)
+					try {
+						await db.insertMapping(provider, senderId, viaSibling)
+					} catch (err) {
+						if (err instanceof DuplicateMappingError) {
+							let winner = await db.findUserId(provider, senderId)
+							if (winner) return winner
+						}
+						throw err
+					}
 					return viaSibling
 				}
 			}

--- a/gateway/src/services/user-mapping.ts
+++ b/gateway/src/services/user-mapping.ts
@@ -1,6 +1,7 @@
 export interface UserMappingDb {
 	findUserId(provider: string, senderId: string): Promise<string | null>
 	createUser(seed: { provider: string; senderId: string }): Promise<string>
+	deleteUser(userId: string): Promise<void>
 	insertMapping(provider: string, senderId: string, userId: string): Promise<void>
 }
 
@@ -57,7 +58,12 @@ export function createUserMappingService(options: { db: UserMappingDb }): UserMa
 			} catch (err) {
 				if (err instanceof DuplicateMappingError) {
 					let winner = await db.findUserId(provider, senderId)
-					if (winner) return winner
+					if (winner) {
+						try {
+							await db.deleteUser(userId)
+						} catch {}
+						return winner
+					}
 				}
 				throw err
 			}

--- a/gateway/src/services/user-mapping.ts
+++ b/gateway/src/services/user-mapping.ts
@@ -19,12 +19,16 @@ export interface UserMappingService {
 	resolveOrCreate(provider: string, senderId: string): Promise<string>
 }
 
-const PHONE_PROVIDERS = ['whatsapp', 'sms'] as const
+export const PHONE_PROVIDERS = ['whatsapp', 'sms'] as const
+
+export type PhoneProvider = (typeof PHONE_PROVIDERS)[number]
+
+export function isPhoneProvider(provider: string): provider is PhoneProvider {
+	return PHONE_PROVIDERS.includes(provider as PhoneProvider)
+}
 
 function phoneSiblingsOf(provider: string): string[] {
-	if (!PHONE_PROVIDERS.includes(provider as (typeof PHONE_PROVIDERS)[number])) {
-		return []
-	}
+	if (!isPhoneProvider(provider)) return []
 	return PHONE_PROVIDERS.filter(p => p !== provider)
 }
 

--- a/gateway/src/services/user-mapping.ts
+++ b/gateway/src/services/user-mapping.ts
@@ -19,7 +19,7 @@ export interface UserMappingService {
 	resolveOrCreate(provider: string, senderId: string): Promise<string>
 }
 
-export const PHONE_PROVIDERS = ['whatsapp', 'sms'] as const
+export let PHONE_PROVIDERS = ['whatsapp', 'sms'] as const
 
 export type PhoneProvider = (typeof PHONE_PROVIDERS)[number]
 

--- a/gateway/src/store/index.ts
+++ b/gateway/src/store/index.ts
@@ -5,3 +5,4 @@ export {
 	type NewConversationMessage,
 	type ConversationDb,
 } from './conversations'
+export { createSupabaseUserMappingDb } from './user-provider-mappings'

--- a/gateway/src/store/user-provider-mappings.ts
+++ b/gateway/src/store/user-provider-mappings.ts
@@ -39,6 +39,11 @@ export function createSupabaseUserMappingDb(
 			return user.id
 		},
 
+		async deleteUser(userId) {
+			let { error } = await client.auth.admin.deleteUser(userId)
+			if (error) throw new Error(error.message)
+		},
+
 		async insertMapping(provider, senderId, userId) {
 			let { error } = await client.from(table).insert({
 				provider,

--- a/gateway/src/store/user-provider-mappings.ts
+++ b/gateway/src/store/user-provider-mappings.ts
@@ -2,7 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js'
 import { z } from 'zod'
 import { DuplicateMappingError, type UserMappingDb } from '../services/user-mapping'
 
-export let dbRowSchema = z.object({
+export const dbRowSchema = z.object({
 	provider: z.string(),
 	sender_id: z.string(),
 	user_id: z.string(),

--- a/gateway/src/store/user-provider-mappings.ts
+++ b/gateway/src/store/user-provider-mappings.ts
@@ -1,6 +1,33 @@
 import type { SupabaseClient } from '@supabase/supabase-js'
 import { z } from 'zod'
-import { DuplicateMappingError, type UserMappingDb } from '../services/user-mapping'
+import {
+	DuplicateMappingError,
+	isPhoneProvider,
+	type UserMappingDb,
+} from '../services/user-mapping'
+
+const SYNTHETIC_EMAIL_DOMAIN = 'gateway.matchmaker.invalid'
+
+type AuthAdminCreateUserArgs = {
+	email?: string
+	email_confirm?: boolean
+	phone?: string
+	phone_confirm?: boolean
+	user_metadata?: Record<string, unknown>
+}
+
+function buildAuthCredentials(
+	provider: string,
+	senderId: string,
+): Pick<AuthAdminCreateUserArgs, 'email' | 'email_confirm' | 'phone' | 'phone_confirm'> {
+	if (isPhoneProvider(provider)) {
+		return { phone: senderId, phone_confirm: true }
+	}
+	return {
+		email: `${provider}-${senderId}@${SYNTHETIC_EMAIL_DOMAIN}`,
+		email_confirm: true,
+	}
+}
 
 export const dbRowSchema = z.object({
 	provider: z.string(),
@@ -34,6 +61,7 @@ export function createSupabaseUserMappingDb(
 
 		async createUser(seed) {
 			let { data, error } = await client.auth.admin.createUser({
+				...buildAuthCredentials(seed.provider, seed.senderId),
 				user_metadata: { provider: seed.provider, sender_id: seed.senderId },
 			})
 			if (error) throw new Error(error.message, { cause: error })

--- a/gateway/src/store/user-provider-mappings.ts
+++ b/gateway/src/store/user-provider-mappings.ts
@@ -25,7 +25,7 @@ export function createSupabaseUserMappingDb(
 				.eq('provider', provider)
 				.eq('sender_id', senderId)
 				.maybeSingle()
-			if (error) throw new Error(error.message)
+			if (error) throw new Error(error.message, { cause: error })
 			return (data as { user_id: string } | null)?.user_id ?? null
 		},
 
@@ -33,7 +33,7 @@ export function createSupabaseUserMappingDb(
 			let { data, error } = await client.auth.admin.createUser({
 				user_metadata: { provider: seed.provider, sender_id: seed.senderId },
 			})
-			if (error) throw new Error(error.message)
+			if (error) throw new Error(error.message, { cause: error })
 			let user = data?.user
 			if (!user) throw new Error('Supabase auth.admin.createUser returned no user')
 			return user.id
@@ -41,7 +41,7 @@ export function createSupabaseUserMappingDb(
 
 		async deleteUser(userId) {
 			let { error } = await client.auth.admin.deleteUser(userId)
-			if (error) throw new Error(error.message)
+			if (error) throw new Error(error.message, { cause: error })
 		},
 
 		async insertMapping(provider, senderId, userId) {
@@ -56,7 +56,7 @@ export function createSupabaseUserMappingDb(
 			if (code === POSTGRES_UNIQUE_VIOLATION) {
 				throw new DuplicateMappingError(provider, senderId)
 			}
-			throw new Error(error.message)
+			throw new Error(error.message, { cause: error })
 		},
 	}
 }

--- a/gateway/src/store/user-provider-mappings.ts
+++ b/gateway/src/store/user-provider-mappings.ts
@@ -11,6 +11,8 @@ export let dbRowSchema = z.object({
 
 export type DbRow = z.infer<typeof dbRowSchema>
 
+const userIdRowSchema = dbRowSchema.pick({ user_id: true })
+
 const POSTGRES_UNIQUE_VIOLATION = '23505'
 
 export function createSupabaseUserMappingDb(
@@ -26,7 +28,8 @@ export function createSupabaseUserMappingDb(
 				.eq('sender_id', senderId)
 				.maybeSingle()
 			if (error) throw new Error(error.message, { cause: error })
-			return (data as { user_id: string } | null)?.user_id ?? null
+			if (data === null) return null
+			return userIdRowSchema.parse(data).user_id
 		},
 
 		async createUser(seed) {

--- a/gateway/src/store/user-provider-mappings.ts
+++ b/gateway/src/store/user-provider-mappings.ts
@@ -1,0 +1,57 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { z } from 'zod'
+import { DuplicateMappingError, type UserMappingDb } from '../services/user-mapping'
+
+export let dbRowSchema = z.object({
+	provider: z.string(),
+	sender_id: z.string(),
+	user_id: z.string(),
+	created_at: z.string(),
+})
+
+export type DbRow = z.infer<typeof dbRowSchema>
+
+const POSTGRES_UNIQUE_VIOLATION = '23505'
+
+export function createSupabaseUserMappingDb(
+	client: SupabaseClient,
+	table = 'user_provider_mappings',
+): UserMappingDb {
+	return {
+		async findUserId(provider, senderId) {
+			let { data, error } = await client
+				.from(table)
+				.select('user_id')
+				.eq('provider', provider)
+				.eq('sender_id', senderId)
+				.maybeSingle()
+			if (error) throw new Error(error.message)
+			return (data as { user_id: string } | null)?.user_id ?? null
+		},
+
+		async createUser(seed) {
+			let { data, error } = await client.auth.admin.createUser({
+				user_metadata: { provider: seed.provider, sender_id: seed.senderId },
+			})
+			if (error) throw new Error(error.message)
+			let user = data?.user
+			if (!user) throw new Error('Supabase auth.admin.createUser returned no user')
+			return user.id
+		},
+
+		async insertMapping(provider, senderId, userId) {
+			let { error } = await client.from(table).insert({
+				provider,
+				sender_id: senderId,
+				user_id: userId,
+			})
+			if (!error) return
+
+			let code = (error as { code?: string }).code
+			if (code === POSTGRES_UNIQUE_VIOLATION) {
+				throw new DuplicateMappingError(provider, senderId)
+			}
+			throw new Error(error.message)
+		},
+	}
+}

--- a/gateway/src/store/user-provider-mappings.ts
+++ b/gateway/src/store/user-provider-mappings.ts
@@ -29,7 +29,7 @@ function buildAuthCredentials(
 	}
 }
 
-export const dbRowSchema = z.object({
+export let dbRowSchema = z.object({
 	provider: z.string(),
 	sender_id: z.string(),
 	user_id: z.string(),
@@ -38,7 +38,7 @@ export const dbRowSchema = z.object({
 
 export type DbRow = z.infer<typeof dbRowSchema>
 
-const userIdRowSchema = dbRowSchema.pick({ user_id: true })
+let userIdRowSchema = dbRowSchema.pick({ user_id: true })
 
 const POSTGRES_UNIQUE_VIOLATION = '23505'
 

--- a/gateway/tests/services/user-mapping.test.ts
+++ b/gateway/tests/services/user-mapping.test.ts
@@ -21,6 +21,7 @@ function makeInMemoryDb(): { db: UserMappingDb; created: string[]; mappings: Map
 			created.push(id)
 			return id
 		},
+		async deleteUser() {},
 		async insertMapping(provider, senderId, userId) {
 			mappings.set(`${provider}:${senderId}`, userId)
 		},
@@ -81,6 +82,7 @@ describe('createUserMappingService', () => {
 				async createUser() {
 					throw new Error('createUser should not be called when a sibling exists')
 				},
+				async deleteUser() {},
 				async insertMapping(provider, senderId, userId) {
 					insertCount++
 					let order = insertCount
@@ -107,9 +109,10 @@ describe('createUserMappingService', () => {
 			expect(mappings.get('sms:+15551234567')).toBe('abc-123')
 		})
 
-		test('returns the winner id when both calls pass findUserId before either inserts', async () => {
+		test('returns the winner id and deletes the orphaned auth user on lost createUser race', async () => {
 			let mappings = new Map<MappingKey, string>()
 			let created: string[] = []
+			let deleted: string[] = []
 			let nextUserId = 1
 			let insertCount = 0
 			let releaseFirstInsert: (() => void) | undefined
@@ -125,6 +128,9 @@ describe('createUserMappingService', () => {
 					let id = `user-${nextUserId++}`
 					created.push(id)
 					return id
+				},
+				async deleteUser(userId) {
+					deleted.push(userId)
 				},
 				async insertMapping(provider, senderId, userId) {
 					insertCount++
@@ -150,6 +156,8 @@ describe('createUserMappingService', () => {
 			expect(created).toHaveLength(2)
 			expect(mappings.size).toBe(1)
 			expect(mappings.get('telegram:99999')).toBe(firstId)
+			let loser = created.find(id => id !== firstId)
+			expect(deleted).toEqual([loser!])
 		})
 
 		test('does not create duplicates when two first-contact calls race', async () => {
@@ -173,6 +181,7 @@ describe('createUserMappingService', () => {
 					created.push(id)
 					return id
 				},
+				async deleteUser() {},
 				async insertMapping(provider, senderId, userId) {
 					let key: MappingKey = `${provider}:${senderId}`
 					if (mappings.has(key)) {

--- a/gateway/tests/services/user-mapping.test.ts
+++ b/gateway/tests/services/user-mapping.test.ts
@@ -1,0 +1,114 @@
+import { describe, test, expect } from 'bun:test'
+import {
+	createUserMappingService,
+	DuplicateMappingError,
+	type UserMappingDb,
+} from '../../src/services/user-mapping'
+
+type MappingKey = `${string}:${string}`
+
+function makeInMemoryDb(): { db: UserMappingDb; created: string[]; mappings: Map<MappingKey, string> } {
+	let created: string[] = []
+	let mappings = new Map<MappingKey, string>()
+	let nextUserId = 1
+
+	let db: UserMappingDb = {
+		async findUserId(provider, senderId) {
+			return mappings.get(`${provider}:${senderId}`) ?? null
+		},
+		async createUser() {
+			let id = `user-${nextUserId++}`
+			created.push(id)
+			return id
+		},
+		async insertMapping(provider, senderId, userId) {
+			mappings.set(`${provider}:${senderId}`, userId)
+		},
+	}
+
+	return { db, created, mappings }
+}
+
+describe('createUserMappingService', () => {
+	describe('resolveOrCreate', () => {
+		test('provisions a new user and mapping when no mapping exists', async () => {
+			let { db, created, mappings } = makeInMemoryDb()
+			let service = createUserMappingService({ db })
+
+			let userId = await service.resolveOrCreate('telegram', '12345')
+
+			expect(created).toEqual([userId])
+			expect(mappings.get('telegram:12345')).toBe(userId)
+		})
+
+		test('returns the existing userId without side effects when a mapping already exists', async () => {
+			let { db, created, mappings } = makeInMemoryDb()
+			mappings.set('telegram:12345', 'abc-123')
+			let service = createUserMappingService({ db })
+
+			let userId = await service.resolveOrCreate('telegram', '12345')
+
+			expect(userId).toBe('abc-123')
+			expect(created).toEqual([])
+			expect(mappings.size).toBe(1)
+		})
+
+		test('deduplicates phone numbers across whatsapp and sms', async () => {
+			let { db, created, mappings } = makeInMemoryDb()
+			mappings.set('whatsapp:+15551234567', 'abc-123')
+			let service = createUserMappingService({ db })
+
+			let userId = await service.resolveOrCreate('sms', '+15551234567')
+
+			expect(userId).toBe('abc-123')
+			expect(created).toEqual([])
+			expect(mappings.get('sms:+15551234567')).toBe('abc-123')
+		})
+
+		test('does not create duplicates when two first-contact calls race', async () => {
+			let mappings = new Map<MappingKey, string>()
+			let created: string[] = []
+			let nextUserId = 1
+			let releaseFirstFind: (() => void) | undefined
+			let firstFindPaused = new Promise<void>(resolve => {
+				releaseFirstFind = resolve
+			})
+			let findCount = 0
+
+			let db: UserMappingDb = {
+				async findUserId(provider, senderId) {
+					findCount++
+					if (findCount === 1) await firstFindPaused
+					return mappings.get(`${provider}:${senderId}`) ?? null
+				},
+				async createUser() {
+					let id = `user-${nextUserId++}`
+					created.push(id)
+					return id
+				},
+				async insertMapping(provider, senderId, userId) {
+					let key: MappingKey = `${provider}:${senderId}`
+					if (mappings.has(key)) {
+						throw new DuplicateMappingError(provider, senderId)
+					}
+					mappings.set(key, userId)
+				},
+			}
+
+			let service = createUserMappingService({ db })
+
+			let firstCall = service.resolveOrCreate('telegram', '99999')
+			let secondCall = service.resolveOrCreate('telegram', '99999')
+			await Promise.resolve()
+			await Promise.resolve()
+			releaseFirstFind!()
+
+			let [firstId, secondId] = await Promise.all([firstCall, secondCall])
+
+			expect(firstId).toBe(secondId)
+			expect(created).toHaveLength(1)
+			expect(mappings.size).toBe(1)
+			expect(mappings.get('telegram:99999')).toBe(firstId)
+		})
+	})
+})

--- a/gateway/tests/services/user-mapping.test.ts
+++ b/gateway/tests/services/user-mapping.test.ts
@@ -65,6 +65,51 @@ describe('createUserMappingService', () => {
 			expect(mappings.get('sms:+15551234567')).toBe('abc-123')
 		})
 
+		test('returns the winner id when both calls pass findUserId before either inserts', async () => {
+			let mappings = new Map<MappingKey, string>()
+			let created: string[] = []
+			let nextUserId = 1
+			let insertCount = 0
+			let releaseFirstInsert: (() => void) | undefined
+			let firstInsertGate = new Promise<void>(resolve => {
+				releaseFirstInsert = resolve
+			})
+
+			let db: UserMappingDb = {
+				async findUserId(provider, senderId) {
+					return mappings.get(`${provider}:${senderId}`) ?? null
+				},
+				async createUser() {
+					let id = `user-${nextUserId++}`
+					created.push(id)
+					return id
+				},
+				async insertMapping(provider, senderId, userId) {
+					insertCount++
+					let order = insertCount
+					let key: MappingKey = `${provider}:${senderId}`
+					if (order === 1) await firstInsertGate
+					if (mappings.has(key)) {
+						throw new DuplicateMappingError(provider, senderId)
+					}
+					mappings.set(key, userId)
+					if (order === 2) releaseFirstInsert!()
+				},
+			}
+
+			let service = createUserMappingService({ db })
+
+			let [firstId, secondId] = await Promise.all([
+				service.resolveOrCreate('telegram', '99999'),
+				service.resolveOrCreate('telegram', '99999'),
+			])
+
+			expect(firstId).toBe(secondId)
+			expect(created).toHaveLength(2)
+			expect(mappings.size).toBe(1)
+			expect(mappings.get('telegram:99999')).toBe(firstId)
+		})
+
 		test('does not create duplicates when two first-contact calls race', async () => {
 			let mappings = new Map<MappingKey, string>()
 			let created: string[] = []

--- a/gateway/tests/services/user-mapping.test.ts
+++ b/gateway/tests/services/user-mapping.test.ts
@@ -65,6 +65,48 @@ describe('createUserMappingService', () => {
 			expect(mappings.get('sms:+15551234567')).toBe('abc-123')
 		})
 
+		test('returns the existing sibling id when two phone-sibling backfills race', async () => {
+			let mappings = new Map<MappingKey, string>()
+			mappings.set('whatsapp:+15551234567', 'abc-123')
+			let insertCount = 0
+			let releaseFirstInsert: (() => void) | undefined
+			let firstInsertGate = new Promise<void>(resolve => {
+				releaseFirstInsert = resolve
+			})
+
+			let db: UserMappingDb = {
+				async findUserId(provider, senderId) {
+					return mappings.get(`${provider}:${senderId}`) ?? null
+				},
+				async createUser() {
+					throw new Error('createUser should not be called when a sibling exists')
+				},
+				async insertMapping(provider, senderId, userId) {
+					insertCount++
+					let order = insertCount
+					let key: MappingKey = `${provider}:${senderId}`
+					if (order === 1) await firstInsertGate
+					if (mappings.has(key)) {
+						throw new DuplicateMappingError(provider, senderId)
+					}
+					mappings.set(key, userId)
+					if (order === 2) releaseFirstInsert!()
+				},
+			}
+
+			let service = createUserMappingService({ db })
+
+			let [firstId, secondId] = await Promise.all([
+				service.resolveOrCreate('sms', '+15551234567'),
+				service.resolveOrCreate('sms', '+15551234567'),
+			])
+
+			expect(firstId).toBe('abc-123')
+			expect(secondId).toBe('abc-123')
+			expect(mappings.size).toBe(2)
+			expect(mappings.get('sms:+15551234567')).toBe('abc-123')
+		})
+
 		test('returns the winner id when both calls pass findUserId before either inserts', async () => {
 			let mappings = new Map<MappingKey, string>()
 			let created: string[] = []

--- a/gateway/tests/store/user-provider-mappings.test.ts
+++ b/gateway/tests/store/user-provider-mappings.test.ts
@@ -1,0 +1,300 @@
+import { describe, test, expect, mock, beforeEach } from 'bun:test'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { createSupabaseUserMappingDb } from '../../src/store/user-provider-mappings'
+import { DuplicateMappingError } from '../../src/services/user-mapping'
+
+type MaybeSingleResult = {
+	data: { user_id: string } | null
+	error: { message: string; code?: string } | null
+}
+
+type InsertResult = { error: { message: string; code?: string } | null }
+
+type FromShape = {
+	insert: (values: Record<string, unknown>) => Promise<InsertResult>
+	select: (columns: string) => {
+		eq: (
+			column: string,
+			value: string,
+		) => {
+			eq: (
+				column: string,
+				value: string,
+			) => {
+				maybeSingle: () => Promise<MaybeSingleResult>
+			}
+		}
+	}
+}
+
+type AuthAdminCreateUserArg = {
+	user_metadata?: Record<string, unknown>
+	[key: string]: unknown
+}
+
+type AuthAdmin = {
+	createUser: (args: AuthAdminCreateUserArg) => Promise<{
+		data: { user: { id: string } | null }
+		error: { message: string } | null
+	}>
+}
+
+type MockClient = {
+	from: (table: string) => FromShape
+	auth: { admin: AuthAdmin }
+}
+
+function asSupabase(client: MockClient): SupabaseClient {
+	return client as unknown as SupabaseClient
+}
+
+function defaultFromShape(): FromShape {
+	return {
+		insert: () => Promise.resolve({ error: null }),
+		select: () => ({
+			eq: () => ({
+				eq: () => ({
+					maybeSingle: () => Promise.resolve({ data: null, error: null }),
+				}),
+			}),
+		}),
+	}
+}
+
+function createMockClient(overrides: Partial<MockClient> = {}): MockClient {
+	return {
+		from: overrides.from ?? (() => defaultFromShape()),
+		auth: overrides.auth ?? {
+			admin: {
+				createUser: async () => ({
+					data: { user: { id: 'auth-user-1' } },
+					error: null,
+				}),
+			},
+		},
+	}
+}
+
+describe('createSupabaseUserMappingDb', () => {
+	let client: MockClient
+
+	beforeEach(() => {
+		client = createMockClient()
+	})
+
+	describe('findUserId', () => {
+		test('chains select(user_id) → eq(provider) → eq(sender_id) → maybeSingle', async () => {
+			let calls = {
+				table: '',
+				select: '',
+				eq1: { column: '', value: '' },
+				eq2: { column: '', value: '' },
+			}
+			client = createMockClient({
+				from: (table: string) => {
+					calls.table = table
+					return {
+						insert: () => Promise.resolve({ error: null }),
+						select: (columns: string) => {
+							calls.select = columns
+							return {
+								eq: (col1: string, val1: string) => {
+									calls.eq1 = { column: col1, value: val1 }
+									return {
+										eq: (col2: string, val2: string) => {
+											calls.eq2 = { column: col2, value: val2 }
+											return {
+												maybeSingle: () =>
+													Promise.resolve({ data: null, error: null }),
+											}
+										},
+									}
+								},
+							}
+						},
+					}
+				},
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await db.findUserId('telegram', '12345')
+
+			expect(calls.table).toBe('user_provider_mappings')
+			expect(calls.select).toBe('user_id')
+			expect(calls.eq1).toEqual({ column: 'provider', value: 'telegram' })
+			expect(calls.eq2).toEqual({ column: 'sender_id', value: '12345' })
+		})
+
+		test('returns the user_id when a row is found', async () => {
+			client = createMockClient({
+				from: () => ({
+					insert: () => Promise.resolve({ error: null }),
+					select: () => ({
+						eq: () => ({
+							eq: () => ({
+								maybeSingle: () =>
+									Promise.resolve({ data: { user_id: 'abc-123' }, error: null }),
+							}),
+						}),
+					}),
+				}),
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			let result = await db.findUserId('telegram', '12345')
+
+			expect(result).toBe('abc-123')
+		})
+
+		test('returns null when no row is found', async () => {
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			let result = await db.findUserId('telegram', '12345')
+
+			expect(result).toBeNull()
+		})
+
+		test('throws when Supabase returns an error', async () => {
+			client = createMockClient({
+				from: () => ({
+					insert: () => Promise.resolve({ error: null }),
+					select: () => ({
+						eq: () => ({
+							eq: () => ({
+								maybeSingle: () =>
+									Promise.resolve({ data: null, error: { message: 'lookup failed' } }),
+							}),
+						}),
+					}),
+				}),
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await expect(db.findUserId('telegram', '12345')).rejects.toThrow('lookup failed')
+		})
+	})
+
+	describe('createUser', () => {
+		test('calls auth.admin.createUser with provider/sender metadata and returns the new auth user id', async () => {
+			let createUserMock = mock(async (_args: AuthAdminCreateUserArg) => ({
+				data: { user: { id: 'new-user-id' } },
+				error: null as { message: string } | null,
+			}))
+			client = createMockClient({
+				auth: { admin: { createUser: createUserMock } },
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			let id = await db.createUser({ provider: 'telegram', senderId: '12345' })
+
+			expect(id).toBe('new-user-id')
+			expect(createUserMock).toHaveBeenCalledTimes(1)
+			let arg = createUserMock.mock.calls[0]?.[0] as AuthAdminCreateUserArg
+			expect(arg.user_metadata).toMatchObject({
+				provider: 'telegram',
+				sender_id: '12345',
+			})
+		})
+
+		test('throws when Supabase auth returns an error', async () => {
+			client = createMockClient({
+				auth: {
+					admin: {
+						createUser: async () => ({
+							data: { user: null },
+							error: { message: 'auth admin down' },
+						}),
+					},
+				},
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await expect(
+				db.createUser({ provider: 'telegram', senderId: '12345' }),
+			).rejects.toThrow('auth admin down')
+		})
+	})
+
+	describe('insertMapping', () => {
+		test('inserts the row into user_provider_mappings', async () => {
+			let insertMock = mock((_row: Record<string, unknown>) =>
+				Promise.resolve({ error: null }),
+			)
+			let fromMock = mock((_table: string) => ({
+				insert: insertMock,
+				select: () => ({
+					eq: () => ({
+						eq: () => ({
+							maybeSingle: () => Promise.resolve({ data: null, error: null }),
+						}),
+					}),
+				}),
+			}))
+			client = createMockClient({ from: fromMock as unknown as MockClient['from'] })
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await db.insertMapping('telegram', '12345', 'abc-123')
+
+			expect(fromMock).toHaveBeenCalledWith('user_provider_mappings')
+			expect(insertMock).toHaveBeenCalledTimes(1)
+			expect(insertMock.mock.calls[0]?.[0]).toEqual({
+				provider: 'telegram',
+				sender_id: '12345',
+				user_id: 'abc-123',
+			})
+		})
+
+		test('translates Postgres unique-violation (23505) into DuplicateMappingError', async () => {
+			client = createMockClient({
+				from: () => ({
+					insert: () =>
+						Promise.resolve({
+							error: { message: 'duplicate key', code: '23505' },
+						}),
+					select: () => ({
+						eq: () => ({
+							eq: () => ({
+								maybeSingle: () => Promise.resolve({ data: null, error: null }),
+							}),
+						}),
+					}),
+				}),
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await expect(
+				db.insertMapping('telegram', '12345', 'abc-123'),
+			).rejects.toBeInstanceOf(DuplicateMappingError)
+		})
+
+		test('throws plain Error for non-unique-violation errors', async () => {
+			client = createMockClient({
+				from: () => ({
+					insert: () =>
+						Promise.resolve({
+							error: { message: 'permission denied', code: '42501' },
+						}),
+					select: () => ({
+						eq: () => ({
+							eq: () => ({
+								maybeSingle: () => Promise.resolve({ data: null, error: null }),
+							}),
+						}),
+					}),
+				}),
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			let caught: unknown = null
+			try {
+				await db.insertMapping('telegram', '12345', 'abc-123')
+			} catch (err) {
+				caught = err
+			}
+
+			expect(caught).toBeInstanceOf(Error)
+			expect(caught).not.toBeInstanceOf(DuplicateMappingError)
+			expect((caught as Error).message).toBe('permission denied')
+		})
+	})
+})

--- a/gateway/tests/store/user-provider-mappings.test.ts
+++ b/gateway/tests/store/user-provider-mappings.test.ts
@@ -37,6 +37,10 @@ type AuthAdmin = {
 		data: { user: { id: string } | null }
 		error: { message: string } | null
 	}>
+	deleteUser: (userId: string) => Promise<{
+		data: Record<string, unknown> | null
+		error: { message: string } | null
+	}>
 }
 
 type MockClient = {
@@ -70,6 +74,7 @@ function createMockClient(overrides: Partial<MockClient> = {}): MockClient {
 					data: { user: { id: 'auth-user-1' } },
 					error: null,
 				}),
+				deleteUser: async () => ({ data: {}, error: null }),
 			},
 		},
 	}
@@ -181,7 +186,12 @@ describe('createSupabaseUserMappingDb', () => {
 				error: null as { message: string } | null,
 			}))
 			client = createMockClient({
-				auth: { admin: { createUser: createUserMock } },
+				auth: {
+					admin: {
+						createUser: createUserMock,
+						deleteUser: async () => ({ data: {}, error: null }),
+					},
+				},
 			})
 			let db = createSupabaseUserMappingDb(asSupabase(client))
 
@@ -204,6 +214,7 @@ describe('createSupabaseUserMappingDb', () => {
 							data: { user: null },
 							error: { message: 'auth admin down' },
 						}),
+						deleteUser: async () => ({ data: {}, error: null }),
 					},
 				},
 			})
@@ -212,6 +223,52 @@ describe('createSupabaseUserMappingDb', () => {
 			await expect(
 				db.createUser({ provider: 'telegram', senderId: '12345' }),
 			).rejects.toThrow('auth admin down')
+		})
+	})
+
+	describe('deleteUser', () => {
+		test('calls auth.admin.deleteUser with the given user id', async () => {
+			let deleteUserMock = mock(async (_userId: string) => ({
+				data: {} as Record<string, unknown> | null,
+				error: null as { message: string } | null,
+			}))
+			client = createMockClient({
+				auth: {
+					admin: {
+						createUser: async () => ({
+							data: { user: { id: 'auth-user-1' } },
+							error: null,
+						}),
+						deleteUser: deleteUserMock,
+					},
+				},
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await db.deleteUser('abc-123')
+
+			expect(deleteUserMock).toHaveBeenCalledTimes(1)
+			expect(deleteUserMock.mock.calls[0]?.[0]).toBe('abc-123')
+		})
+
+		test('throws when Supabase auth returns an error', async () => {
+			client = createMockClient({
+				auth: {
+					admin: {
+						createUser: async () => ({
+							data: { user: { id: 'auth-user-1' } },
+							error: null,
+						}),
+						deleteUser: async () => ({
+							data: null,
+							error: { message: 'delete failed' },
+						}),
+					},
+				},
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await expect(db.deleteUser('abc-123')).rejects.toThrow('delete failed')
 		})
 	})
 

--- a/gateway/tests/store/user-provider-mappings.test.ts
+++ b/gateway/tests/store/user-provider-mappings.test.ts
@@ -238,6 +238,75 @@ describe('createSupabaseUserMappingDb', () => {
 			})
 		})
 
+		test('passes a phone credential with phone_confirm:true for whatsapp', async () => {
+			let createUserMock = mock(async (_args: AuthAdminCreateUserArg) => ({
+				data: { user: { id: 'new-user-id' } },
+				error: null as { message: string } | null,
+			}))
+			client = createMockClient({
+				auth: {
+					admin: {
+						createUser: createUserMock,
+						deleteUser: async () => ({ data: {}, error: null }),
+					},
+				},
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await db.createUser({ provider: 'whatsapp', senderId: '+15551234567' })
+
+			let arg = createUserMock.mock.calls[0]?.[0] as AuthAdminCreateUserArg
+			expect(arg.phone).toBe('+15551234567')
+			expect(arg.phone_confirm).toBe(true)
+			expect(arg.email).toBeUndefined()
+		})
+
+		test('passes a phone credential with phone_confirm:true for sms', async () => {
+			let createUserMock = mock(async (_args: AuthAdminCreateUserArg) => ({
+				data: { user: { id: 'new-user-id' } },
+				error: null as { message: string } | null,
+			}))
+			client = createMockClient({
+				auth: {
+					admin: {
+						createUser: createUserMock,
+						deleteUser: async () => ({ data: {}, error: null }),
+					},
+				},
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await db.createUser({ provider: 'sms', senderId: '+15551234567' })
+
+			let arg = createUserMock.mock.calls[0]?.[0] as AuthAdminCreateUserArg
+			expect(arg.phone).toBe('+15551234567')
+			expect(arg.phone_confirm).toBe(true)
+			expect(arg.email).toBeUndefined()
+		})
+
+		test('passes a synthesized invalid-TLD email with email_confirm:true for non-phone providers', async () => {
+			let createUserMock = mock(async (_args: AuthAdminCreateUserArg) => ({
+				data: { user: { id: 'new-user-id' } },
+				error: null as { message: string } | null,
+			}))
+			client = createMockClient({
+				auth: {
+					admin: {
+						createUser: createUserMock,
+						deleteUser: async () => ({ data: {}, error: null }),
+					},
+				},
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await db.createUser({ provider: 'telegram', senderId: '12345' })
+
+			let arg = createUserMock.mock.calls[0]?.[0] as AuthAdminCreateUserArg
+			expect(arg.email).toBe('telegram-12345@gateway.matchmaker.invalid')
+			expect(arg.email_confirm).toBe(true)
+			expect(arg.phone).toBeUndefined()
+		})
+
 		test('throws preserving the Supabase auth error as cause', async () => {
 			let originalError = { message: 'auth admin down' }
 			client = createMockClient({

--- a/gateway/tests/store/user-provider-mappings.test.ts
+++ b/gateway/tests/store/user-provider-mappings.test.ts
@@ -159,7 +159,8 @@ describe('createSupabaseUserMappingDb', () => {
 			expect(result).toBeNull()
 		})
 
-		test('throws when Supabase returns an error', async () => {
+		test('throws preserving the Supabase error as cause', async () => {
+			let originalError = { message: 'lookup failed', code: '42501' }
 			client = createMockClient({
 				from: () => ({
 					insert: () => Promise.resolve({ error: null }),
@@ -167,7 +168,7 @@ describe('createSupabaseUserMappingDb', () => {
 						eq: () => ({
 							eq: () => ({
 								maybeSingle: () =>
-									Promise.resolve({ data: null, error: { message: 'lookup failed' } }),
+									Promise.resolve({ data: null, error: originalError }),
 							}),
 						}),
 					}),
@@ -175,7 +176,16 @@ describe('createSupabaseUserMappingDb', () => {
 			})
 			let db = createSupabaseUserMappingDb(asSupabase(client))
 
-			await expect(db.findUserId('telegram', '12345')).rejects.toThrow('lookup failed')
+			let caught: unknown = null
+			try {
+				await db.findUserId('telegram', '12345')
+			} catch (err) {
+				caught = err
+			}
+
+			expect(caught).toBeInstanceOf(Error)
+			expect((caught as Error).message).toBe('lookup failed')
+			expect((caught as Error).cause).toBe(originalError)
 		})
 	})
 
@@ -206,13 +216,14 @@ describe('createSupabaseUserMappingDb', () => {
 			})
 		})
 
-		test('throws when Supabase auth returns an error', async () => {
+		test('throws preserving the Supabase auth error as cause', async () => {
+			let originalError = { message: 'auth admin down' }
 			client = createMockClient({
 				auth: {
 					admin: {
 						createUser: async () => ({
 							data: { user: null },
-							error: { message: 'auth admin down' },
+							error: originalError,
 						}),
 						deleteUser: async () => ({ data: {}, error: null }),
 					},
@@ -220,9 +231,16 @@ describe('createSupabaseUserMappingDb', () => {
 			})
 			let db = createSupabaseUserMappingDb(asSupabase(client))
 
-			await expect(
-				db.createUser({ provider: 'telegram', senderId: '12345' }),
-			).rejects.toThrow('auth admin down')
+			let caught: unknown = null
+			try {
+				await db.createUser({ provider: 'telegram', senderId: '12345' })
+			} catch (err) {
+				caught = err
+			}
+
+			expect(caught).toBeInstanceOf(Error)
+			expect((caught as Error).message).toBe('auth admin down')
+			expect((caught as Error).cause).toBe(originalError)
 		})
 	})
 
@@ -251,7 +269,8 @@ describe('createSupabaseUserMappingDb', () => {
 			expect(deleteUserMock.mock.calls[0]?.[0]).toBe('abc-123')
 		})
 
-		test('throws when Supabase auth returns an error', async () => {
+		test('throws preserving the Supabase auth error as cause', async () => {
+			let originalError = { message: 'delete failed' }
 			client = createMockClient({
 				auth: {
 					admin: {
@@ -261,14 +280,23 @@ describe('createSupabaseUserMappingDb', () => {
 						}),
 						deleteUser: async () => ({
 							data: null,
-							error: { message: 'delete failed' },
+							error: originalError,
 						}),
 					},
 				},
 			})
 			let db = createSupabaseUserMappingDb(asSupabase(client))
 
-			await expect(db.deleteUser('abc-123')).rejects.toThrow('delete failed')
+			let caught: unknown = null
+			try {
+				await db.deleteUser('abc-123')
+			} catch (err) {
+				caught = err
+			}
+
+			expect(caught).toBeInstanceOf(Error)
+			expect((caught as Error).message).toBe('delete failed')
+			expect((caught as Error).cause).toBe(originalError)
 		})
 	})
 
@@ -324,12 +352,13 @@ describe('createSupabaseUserMappingDb', () => {
 			).rejects.toBeInstanceOf(DuplicateMappingError)
 		})
 
-		test('throws plain Error for non-unique-violation errors', async () => {
+		test('throws plain Error preserving the Supabase error as cause for non-unique-violation errors', async () => {
+			let originalError = { message: 'permission denied', code: '42501' }
 			client = createMockClient({
 				from: () => ({
 					insert: () =>
 						Promise.resolve({
-							error: { message: 'permission denied', code: '42501' },
+							error: originalError,
 						}),
 					select: () => ({
 						eq: () => ({
@@ -352,6 +381,7 @@ describe('createSupabaseUserMappingDb', () => {
 			expect(caught).toBeInstanceOf(Error)
 			expect(caught).not.toBeInstanceOf(DuplicateMappingError)
 			expect((caught as Error).message).toBe('permission denied')
+			expect((caught as Error).cause).toBe(originalError)
 		})
 	})
 })

--- a/gateway/tests/store/user-provider-mappings.test.ts
+++ b/gateway/tests/store/user-provider-mappings.test.ts
@@ -159,6 +159,28 @@ describe('createSupabaseUserMappingDb', () => {
 			expect(result).toBeNull()
 		})
 
+		test('throws when Supabase returns a row missing user_id', async () => {
+			client = createMockClient({
+				from: () => ({
+					insert: () => Promise.resolve({ error: null }),
+					select: () => ({
+						eq: () => ({
+							eq: () => ({
+								maybeSingle: () =>
+									Promise.resolve({
+										data: { wrong_field: 'oops' } as unknown as { user_id: string },
+										error: null,
+									}),
+							}),
+						}),
+					}),
+				}),
+			})
+			let db = createSupabaseUserMappingDb(asSupabase(client))
+
+			await expect(db.findUserId('telegram', '12345')).rejects.toThrow()
+		})
+
 		test('throws preserving the Supabase error as cause', async () => {
 			let originalError = { message: 'lookup failed', code: '42501' }
 			client = createMockClient({

--- a/gateway/tests/store/userProviderMappingsSchemaDrift.test.ts
+++ b/gateway/tests/store/userProviderMappingsSchemaDrift.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Guards against drift between the Zod row schema in the user mapping
+ * store and the actual column list in the SQL migration. Mirrors the
+ * conversations schema-drift test.
+ */
+import { describe, test, expect } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { dbRowSchema } from '../../src/store/user-provider-mappings'
+
+function extractColumnNames(sql: string): string[] {
+	let match = sql.match(
+		/CREATE TABLE\s+(?:public\.)?user_provider_mappings\s*\(([^;]+)\)\s*;/i,
+	)
+	if (!match) throw new Error('could not find CREATE TABLE user_provider_mappings in migration')
+
+	let body = match[1] ?? ''
+	let columns: string[] = []
+	for (let rawLine of body.split('\n')) {
+		let line = rawLine.trim()
+		if (line === '' || line.startsWith('--')) continue
+
+		let firstToken = line.split(/\s+/)[0] ?? ''
+		let name = firstToken.replace(/,$/, '')
+		let upper = name.toUpperCase()
+		if (
+			name === '' ||
+			upper === 'CHECK' ||
+			upper === 'CONSTRAINT' ||
+			upper === 'PRIMARY' ||
+			upper === 'UNIQUE' ||
+			upper === 'FOREIGN'
+		) {
+			continue
+		}
+		columns.push(name)
+	}
+	return columns
+}
+
+describe('user_provider_mappings schema drift', () => {
+	test('Zod dbRowSchema keys match the migration column list exactly', () => {
+		let migrationPath = join(
+			import.meta.dir,
+			'../../../supabase/migrations/20260507000000_add_user_provider_mappings.sql',
+		)
+		let sql = readFileSync(migrationPath, 'utf8')
+
+		let migrationColumns = new Set(extractColumnNames(sql))
+		let schemaKeys = new Set(Object.keys(dbRowSchema.shape))
+
+		expect(schemaKeys).toEqual(migrationColumns)
+	})
+})

--- a/supabase/migrations/20260507000000_add_user_provider_mappings.sql
+++ b/supabase/migrations/20260507000000_add_user_provider_mappings.sql
@@ -2,7 +2,7 @@ CREATE TABLE public.user_provider_mappings (
   provider    TEXT NOT NULL,
   sender_id   TEXT NOT NULL,
   user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
-  created_at  TIMESTAMPTZ DEFAULT now(),
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (provider, sender_id)
 );
 
@@ -10,9 +10,4 @@ CREATE INDEX idx_user_provider_mappings_user ON public.user_provider_mappings(us
 
 ALTER TABLE public.user_provider_mappings ENABLE ROW LEVEL SECURITY;
 
-COMMENT ON TABLE public.user_provider_mappings IS
-  'Maps inbound chat-provider identities ((provider, sender_id) pairs) to '
-  'a Supabase auth.users.id. Accessed only via the service_role key from '
-  'the gateway; RLS is enabled with no policies so anon/authenticated keys '
-  'are denied by default. The composite PK doubles as the unique constraint '
-  'the user-mapping service relies on for concurrent-first-contact safety.';
+COMMENT ON TABLE public.user_provider_mappings IS $$Maps inbound chat-provider identities ((provider, sender_id) pairs) to a Supabase auth.users.id. Accessed only via the service_role key from the gateway; RLS is enabled with no policies so anon/authenticated keys are denied by default. The composite PK doubles as the unique constraint the user-mapping service relies on for concurrent-first-contact safety.$$;

--- a/supabase/migrations/20260507000000_add_user_provider_mappings.sql
+++ b/supabase/migrations/20260507000000_add_user_provider_mappings.sql
@@ -1,0 +1,18 @@
+CREATE TABLE public.user_provider_mappings (
+  provider    TEXT NOT NULL,
+  sender_id   TEXT NOT NULL,
+  user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  created_at  TIMESTAMPTZ DEFAULT now(),
+  PRIMARY KEY (provider, sender_id)
+);
+
+CREATE INDEX idx_user_provider_mappings_user ON public.user_provider_mappings(user_id);
+
+ALTER TABLE public.user_provider_mappings ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.user_provider_mappings IS
+  'Maps inbound chat-provider identities ((provider, sender_id) pairs) to '
+  'a Supabase auth.users.id. Accessed only via the service_role key from '
+  'the gateway; RLS is enabled with no policies so anon/authenticated keys '
+  'are denied by default. The composite PK doubles as the unique constraint '
+  'the user-mapping service relies on for concurrent-first-contact safety.';


### PR DESCRIPTION
Closes #102. Step 7 of the gateway epic (#94).

## Summary
- Adds a transport-agnostic `UserMappingService` (`resolveOrCreate(provider, senderId) → userId`) so every adapter shares one auto-provisioning + identity-linking path.
- Adds a Supabase-backed `UserMappingDb` that calls `auth.admin.createUser` (the existing `handle_new_user` trigger seeds the matchmaker row) and translates Postgres unique-violation `23505` into `DuplicateMappingError`.
- Adds a migration creating `public.user_provider_mappings` with `PRIMARY KEY (provider, sender_id)` and RLS enabled. The composite PK is the source of truth for concurrency safety.

## BDD scenarios from the issue
All four are covered as standalone tests in `gateway/tests/services/user-mapping.test.ts`:
- New telegram user is provisioned (creates auth user + mapping; returns the new id).
- Known user is resolved without side effects.
- WhatsApp ↔ SMS phone-number deduplication (cross-provider lookup, then a backfill insert for the new provider so subsequent calls hit the cache directly).
- Concurrent first-contact calls return the same id and produce a single mapping (in-memory double simulates the race; the production safety net is the DB unique constraint surfaced as `DuplicateMappingError`).

## Notes
- Phone provider list is `[whatsapp, sms]` per planning conversation. Easy to extend.
- The service is exported from `gateway/src/services` but not yet wired into `index.ts`; the Telegram (#100) and WhatsApp (#101) adapter PRs will inject it via `ChatAdapter.resolveUser`.
- Schema-drift test pins the Zod row schema to the migration column list, mirroring the conversations store guard.

## Test plan
- [x] `cd gateway && bun test` (82 pass)
- [x] `cd gateway && bun run typecheck` clean
- [ ] CI: `Test Packages` job runs the gateway suite on PR
- [ ] Reviewer sanity-check: migration `20260507000000_add_user_provider_mappings.sql` slots cleanly after `20260329000000_add_conversations.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)