### PR TITLE
chore(deps): align workspace to zod ^4.4.3

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,7 @@
 		"@modelcontextprotocol/sdk": "^1.0.0",
 		"hono": "^4.0.0",
 		"@supabase/supabase-js": "^2.39.0",
-		"zod": "^4.3.6",
+		"zod": "^4.4.3",
 		"@hono/zod-validator": "^0.7.6"
 	},
 	"devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@supabase/supabase-js": "^2.39.0",
         "hono": "^4.0.0",
-        "zod": "^4.3.6",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.0.0",
@@ -41,7 +41,7 @@
         "ai": "^5.0.0",
         "hono": "^4.0.0",
         "jose": "^5.9.0",
-        "zod": "^4.3.6",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.0.0",
@@ -57,7 +57,7 @@
         "@matchmaker/shared": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@supabase/supabase-js": "^2.39.0",
-        "zod": "^3.22.4",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.0.0",
@@ -71,7 +71,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
-        "zod": "^4.3.6",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.0.0",
@@ -820,7 +820,7 @@
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
@@ -828,9 +828,9 @@
 
     "@fastify/static/content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
 
-    "@matchmaker/mcp-server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@modelcontextprotocol/sdk/jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -20,7 +20,7 @@
 		"ai": "^5.0.0",
 		"hono": "^4.0.0",
 		"jose": "^5.9.0",
-		"zod": "^4.3.6",
+		"zod": "^4.4.3",
 		"@hono/zod-validator": "^0.7.6"
 	},
 	"devDependencies": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -18,7 +18,7 @@
 		"@matchmaker/shared": "workspace:*",
 		"@modelcontextprotocol/sdk": "^1.0.0",
 		"@supabase/supabase-js": "^2.39.0",
-		"zod": "^3.22.4"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.0.0",

--- a/mcp-server/src/api.ts
+++ b/mcp-server/src/api.ts
@@ -26,8 +26,8 @@ let updatePersonInputSchema = z.object({
 	age: z.number().int().positive().optional(),
 	location: z.string().optional(),
 	gender: z.string().optional(),
-	preferences: z.record(z.unknown()).optional(),
-	personality: z.record(z.unknown()).optional(),
+	preferences: z.record(z.string(), z.unknown()).optional(),
+	personality: z.record(z.string(), z.unknown()).optional(),
 	notes: z.string().optional(),
 })
 
@@ -214,7 +214,7 @@ export class ApiClient implements IApiClient {
 			return schema.parse(data)
 		} catch (e) {
 			if (e instanceof z.ZodError) {
-				throw new Error(`API response validation failed: ${e.errors[0]?.message}`)
+				throw new Error(`API response validation failed: ${e.issues[0]?.message}`)
 			}
 			throw e
 		}

--- a/mcp-server/src/schemas.ts
+++ b/mcp-server/src/schemas.ts
@@ -1,83 +1,72 @@
 import { z } from 'zod'
 
-export const personResponseSchema = z
-	.object({
-		id: z.string().uuid(),
-		matchmaker_id: z.string().uuid(),
-		name: z.string(),
-		age: z.number().nullable(),
-		location: z.string().nullable(),
-		gender: z.string().nullable(),
-		preferences: z.record(z.unknown()).nullable(),
-		personality: z.record(z.unknown()).nullable(),
-		notes: z.string().nullable(),
-		active: z.boolean(),
-		created_at: z.string(),
-		updated_at: z.string(),
-	})
-	.passthrough()
+export const personResponseSchema = z.looseObject({
+	id: z.string().uuid(),
+	matchmaker_id: z.string().uuid(),
+	name: z.string(),
+	age: z.number().nullable(),
+	location: z.string().nullable(),
+	gender: z.string().nullable(),
+	preferences: z.record(z.string(), z.unknown()).nullable(),
+	personality: z.record(z.string(), z.unknown()).nullable(),
+	notes: z.string().nullable(),
+	active: z.boolean(),
+	created_at: z.string(),
+	updated_at: z.string(),
+})
 
 export const peopleListResponseSchema = z.array(personResponseSchema)
 
-export const introductionResponseSchema = z
-	.object({
-		id: z.string().uuid(),
-		matchmaker_id: z.string().uuid(),
-		person_a_id: z.string().uuid(),
-		person_b_id: z.string().uuid(),
-		status: z.string(),
-		notes: z.string().nullable(),
-		created_at: z.string(),
-		updated_at: z.string(),
-	})
-	.passthrough()
+export const introductionResponseSchema = z.looseObject({
+	id: z.string().uuid(),
+	matchmaker_id: z.string().uuid(),
+	person_a_id: z.string().uuid(),
+	person_b_id: z.string().uuid(),
+	status: z.string(),
+	notes: z.string().nullable(),
+	created_at: z.string(),
+	updated_at: z.string(),
+})
 
 export const introductionsListResponseSchema = z.array(introductionResponseSchema)
 
 // Match schema - currently placeholder, will be expanded when algorithm is implemented
-export const matchResponseSchema = z
-	.object({
-		person: z
-			.object({
-				id: z.string().uuid(),
-				name: z.string(),
-				age: z.number().nullable().optional(),
-				location: z.string().nullable().optional(),
-			})
-			.passthrough()
-			.optional(),
-		compatibility_score: z.number().optional(),
-		match_reasons: z.array(z.string()).optional(),
-	})
-	.passthrough()
+export const matchResponseSchema = z.looseObject({
+	person: z
+		.looseObject({
+			id: z.string().uuid(),
+			name: z.string(),
+			age: z.number().nullable().optional(),
+			location: z.string().nullable().optional(),
+		})
+		.optional(),
+	compatibility_score: z.number().optional(),
+	match_reasons: z.array(z.string()).optional(),
+})
 
 export const matchesListResponseSchema = z.array(matchResponseSchema)
 
 // Feedback schema
-export const feedbackResponseSchema = z
-	.object({
-		id: z.string().uuid(),
-		introduction_id: z.string().uuid(),
-		from_person_id: z.string().uuid(),
-		content: z.string(),
-		sentiment: z.string().nullable(),
-		created_at: z.string(),
-	})
-	.passthrough()
+export const feedbackResponseSchema = z.looseObject({
+	id: z.string().uuid(),
+	introduction_id: z.string().uuid(),
+	from_person_id: z.string().uuid(),
+	content: z.string(),
+	sentiment: z.string().nullable(),
+	created_at: z.string(),
+})
 
 export const feedbackListResponseSchema = z.array(feedbackResponseSchema)
 
 // Match decision schema
-export const matchDecisionResponseSchema = z
-	.object({
-		id: z.string().uuid(),
-		matchmaker_id: z.string().uuid(),
-		person_id: z.string().uuid(),
-		candidate_id: z.string().uuid(),
-		decision: z.enum(['accepted', 'declined']),
-		decline_reason: z.string().nullable(),
-		created_at: z.string(),
-	})
-	.passthrough()
+export const matchDecisionResponseSchema = z.looseObject({
+	id: z.string().uuid(),
+	matchmaker_id: z.string().uuid(),
+	person_id: z.string().uuid(),
+	candidate_id: z.string().uuid(),
+	decision: z.enum(['accepted', 'declined']),
+	decline_reason: z.string().nullable(),
+	created_at: z.string(),
+})
 
 export const matchDecisionsListResponseSchema = z.array(matchDecisionResponseSchema)

--- a/mcp-server/tests/schemas.test.ts
+++ b/mcp-server/tests/schemas.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect } from 'bun:test'
+import { z } from 'zod'
+import {
+	personResponseSchema,
+	introductionResponseSchema,
+	matchResponseSchema,
+	feedbackResponseSchema,
+	matchDecisionResponseSchema,
+} from '../src/schemas'
+
+let basePerson = {
+	id: '550e8400-e29b-41d4-a716-446655440000',
+	matchmaker_id: '123e4567-e89b-12d3-a456-426614174000',
+	name: 'Alice',
+	age: 28,
+	location: 'New York',
+	gender: 'female',
+	preferences: { age_min: 25 },
+	personality: { traits: ['kind'] },
+	notes: null,
+	active: true,
+	created_at: '2026-01-01T00:00:00Z',
+	updated_at: '2026-01-01T00:00:00Z',
+}
+
+let baseIntroduction = {
+	id: '660e8400-e29b-41d4-a716-446655440001',
+	matchmaker_id: '123e4567-e89b-12d3-a456-426614174000',
+	person_a_id: '550e8400-e29b-41d4-a716-446655440000',
+	person_b_id: '550e8400-e29b-41d4-a716-446655440002',
+	status: 'pending',
+	notes: null,
+	created_at: '2026-01-01T00:00:00Z',
+	updated_at: '2026-01-01T00:00:00Z',
+}
+
+let baseFeedback = {
+	id: '770e8400-e29b-41d4-a716-446655440003',
+	introduction_id: '660e8400-e29b-41d4-a716-446655440001',
+	from_person_id: '550e8400-e29b-41d4-a716-446655440000',
+	content: 'Great connection',
+	sentiment: 'positive',
+	created_at: '2026-01-01T00:00:00Z',
+}
+
+let baseMatchDecision = {
+	id: '880e8400-e29b-41d4-a716-446655440004',
+	matchmaker_id: '123e4567-e89b-12d3-a456-426614174000',
+	person_id: '550e8400-e29b-41d4-a716-446655440000',
+	candidate_id: '550e8400-e29b-41d4-a716-446655440002',
+	decision: 'accepted' as const,
+	decline_reason: null,
+	created_at: '2026-01-01T00:00:00Z',
+}
+
+describe('personResponseSchema', () => {
+	test('parses a canonical row', () => {
+		expect(() => personResponseSchema.parse(basePerson)).not.toThrow()
+	})
+
+	test('preserves unknown server-side fields (looseObject behavior)', () => {
+		let withExtras = { ...basePerson, extra_field: 'tolerated', server_only: 42 }
+		let parsed = personResponseSchema.parse(withExtras)
+		expect((parsed as Record<string, unknown>).extra_field).toBe('tolerated')
+		expect((parsed as Record<string, unknown>).server_only).toBe(42)
+	})
+
+	test('accepts string-keyed preferences and personality records', () => {
+		let parsed = personResponseSchema.parse({
+			...basePerson,
+			preferences: { foo: 'bar', nested: { ok: true } },
+			personality: { traits: ['warm', 'curious'] },
+		})
+		expect(parsed.preferences).toEqual({ foo: 'bar', nested: { ok: true } })
+	})
+
+	test('rejects rows missing required fields with ZodError', () => {
+		let { name: _, ...withoutName } = basePerson
+		try {
+			personResponseSchema.parse(withoutName)
+			throw new Error('expected schema to throw')
+		} catch (err) {
+			expect(err).toBeInstanceOf(z.ZodError)
+			expect((err as z.ZodError).issues).toBeDefined()
+			expect((err as z.ZodError).issues.length).toBeGreaterThan(0)
+		}
+	})
+})
+
+describe('introductionResponseSchema', () => {
+	test('parses a canonical row and preserves extras', () => {
+		let parsed = introductionResponseSchema.parse({
+			...baseIntroduction,
+			tracking_id: 'abc',
+		})
+		expect((parsed as Record<string, unknown>).tracking_id).toBe('abc')
+	})
+})
+
+describe('matchResponseSchema', () => {
+	test('parses with optional nested person and preserves extras at both levels', () => {
+		let parsed = matchResponseSchema.parse({
+			person: {
+				id: '550e8400-e29b-41d4-a716-446655440000',
+				name: 'Alice',
+				age: 28,
+				location: 'New York',
+				bio: 'tolerated extra on nested looseObject',
+			},
+			compatibility_score: 0.92,
+			match_reasons: ['shared interests'],
+			algorithm_version: 'v2',
+		})
+		expect((parsed as Record<string, unknown>).algorithm_version).toBe('v2')
+		expect((parsed.person as Record<string, unknown>).bio).toBe(
+			'tolerated extra on nested looseObject'
+		)
+	})
+
+	test('parses when person is omitted', () => {
+		expect(() =>
+			matchResponseSchema.parse({
+				compatibility_score: 0.5,
+				match_reasons: ['proximity'],
+			})
+		).not.toThrow()
+	})
+})
+
+describe('feedbackResponseSchema', () => {
+	test('parses a canonical row', () => {
+		expect(() => feedbackResponseSchema.parse(baseFeedback)).not.toThrow()
+	})
+
+	test('exposes ZodError.issues on invalid sentiment type', () => {
+		try {
+			feedbackResponseSchema.parse({ ...baseFeedback, sentiment: 42 })
+			throw new Error('expected schema to throw')
+		} catch (err) {
+			expect(err).toBeInstanceOf(z.ZodError)
+			let issues = (err as z.ZodError).issues
+			expect(issues[0]?.path).toEqual(['sentiment'])
+		}
+	})
+})
+
+describe('matchDecisionResponseSchema', () => {
+	test('parses accepted and declined decisions', () => {
+		expect(() => matchDecisionResponseSchema.parse(baseMatchDecision)).not.toThrow()
+		expect(() =>
+			matchDecisionResponseSchema.parse({
+				...baseMatchDecision,
+				decision: 'declined',
+				decline_reason: 'incompatible',
+			})
+		).not.toThrow()
+	})
+
+	test('rejects decisions outside the enum', () => {
+		try {
+			matchDecisionResponseSchema.parse({ ...baseMatchDecision, decision: 'maybe' })
+			throw new Error('expected schema to throw')
+		} catch (err) {
+			expect(err).toBeInstanceOf(z.ZodError)
+			expect((err as z.ZodError).issues[0]?.path).toEqual(['decision'])
+		}
+	})
+})

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.0.0",
-		"zod": "^4.3.6"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.0.0",

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "@matchmaker/web",
       "dependencies": {
-        "@hookform/resolvers": "^3.3.4",
+        "@hookform/resolvers": "^5.0.0",
         "@supabase/supabase-js": "^2.39.0",
         "clsx": "^2.1.0",
         "lucide-react": "^0.300.0",
@@ -14,7 +14,7 @@
         "react-dom": "^18.3.0",
         "react-hook-form": "^7.51.0",
         "tailwind-merge": "^2.2.0",
-        "zod": "^3.22.4",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.7",
@@ -109,7 +109,7 @@
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
-    "@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
+    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -184,6 +184,8 @@
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@supabase/auth-js": ["@supabase/auth-js@2.89.0", "", { "dependencies": { "tslib": "2.8.1" } }, "sha512-wiWZdz8WMad8LQdJMWYDZ2SJtZP5MwMqzQq3ehtW2ngiI3UTgbKiFrvMUUS3KADiVlk4LiGfODB2mrYx7w2f8w=="],
 
@@ -611,7 +613,7 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
-		"@hookform/resolvers": "^3.3.4",
+		"@hookform/resolvers": "^5.0.0",
 		"@supabase/supabase-js": "^2.39.0",
 		"clsx": "^2.1.0",
 		"lucide-react": "^0.300.0",
@@ -22,7 +22,7 @@
 		"react-dom": "^18.3.0",
 		"react-hook-form": "^7.51.0",
 		"tailwind-merge": "^2.2.0",
-		"zod": "^3.22.4"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@tailwindcss/forms": "^0.5.7",

--- a/web/src/app/api/referral/route.ts
+++ b/web/src/app/api/referral/route.ts
@@ -13,7 +13,7 @@ export async function POST(request: Request) {
 			return NextResponse.json(
 				{
 					error: "Validation failed",
-					details: validationResult.error.errors,
+					details: validationResult.error.issues,
 				},
 				{ status: 400 }
 			);

--- a/web/src/app/api/waitlist/route.ts
+++ b/web/src/app/api/waitlist/route.ts
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
 			return NextResponse.json(
 				{
 					error: "Validation failed",
-					details: error.errors,
+					details: error.issues,
 				},
 				{ status: 400 }
 			);


### PR DESCRIPTION
## Summary

Replaces #120. The dependabot bump touched only `mcp-server`, which left `shared/backend/gateway` on `^4.3.6` and forced bun to nest a separate `zod@4.4.3` under `@matchmaker/shared` — that nested copy broke type identity for AI SDK `inputSchema` consumers in gateway and was the typecheck failure on #120.

This PR aligns the entire workspace so a single `zod` is hoisted, and migrates the v3 → v4 patterns properly with test coverage.

- `chore(deps): align zod to ^4.4.3 across workspace` — bumps mcp-server (3.x → 4.4.3), web (3.x → 4.4.3), and nudges shared/backend/gateway from ^4.3.6 → ^4.4.3 so the lockfile hoists one zod. Web's `@hookform/resolvers` bumps 3.3.4 → 5.0.0 (resolvers v5 is the first version that supports zod 4).
- `refactor(mcp-server): adapt schemas and client to zod v4 API` — `.passthrough()` → `z.looseObject()`, `z.record(z.unknown())` → `z.record(z.string(), z.unknown())`, `ZodError.errors` → `.issues`.
- `test(mcp-server): cover zod v4 schema behavior` — locks in looseObject's preservation of unknown keys, string-keyed `record` round-trips, and the `.issues` access path.
- `refactor(web): use ZodError.issues per zod v4 API` — same rename in the two API route handlers.

## Test plan

- [x] `bun run typecheck` (shared, backend, mcp-server, gateway) — clean
- [x] `bun run test` — 385 backend/shared + 150 mcp-server + 68 gateway pass
- [x] `bunx tsc --noEmit` in `web/` — clean
- [x] `bun run test` in `web/` — 27 vitest pass
- [x] Confirmed root `bun.lock` and `web/bun.lock` each contain a single hoisted `zod@4.4.3` (no nested workspace copies)
- [ ] CI passes (Typecheck + Test + coverage-diff + Vercel preview)
- [ ] Manual smoke of `/api/waitlist` and `/api/referral` validation responses (optional — types and tests already cover the rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)