### PR TITLE
fix(deploy): drop unknown bun provider from nixpacks config

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,4 +1,4 @@
-providers = ["node", "bun"]
+providers = ["node"]
 
 [phases.install]
 cmds = ["bun install --production --frozen-lockfile"]


### PR DESCRIPTION
## Summary
- Railway upgraded its builder to nixpacks v1.41.0, which rejects unknown providers and fails the build with `Error: Provider bun not found`.
- Bun is detected automatically by the Node provider (via `bun.lock`), so listing `bun` separately is unnecessary — drop it from `nixpacks.toml`.
- The existing `bun install --production --frozen-lockfile` install phase is unchanged.

## Test plan
- [ ] Railway deploy of this branch builds successfully past the snapshot-analyze step.
- [ ] Backend container starts via `cd backend && NODE_ENV=production bun --silent run start` and `/health` responds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)