### PR TITLE
feat(gateway): implement Telegram adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@supabase/supabase-js": "^2.39.0",
         "ai": "^5.0.0",
+        "grammy": "^1.42.0",
         "hono": "^4.0.0",
         "jose": "^5.9.0",
         "zod": "^4.4.3",
@@ -161,6 +162,8 @@
     "@fastify/static": ["@fastify/static@8.3.0", "", { "dependencies": { "@fastify/accept-negotiator": "^2.0.0", "@fastify/send": "^4.0.0", "content-disposition": "^0.5.4", "fastify-plugin": "^5.0.0", "fastq": "^1.17.1", "glob": "^11.0.0" } }, "sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA=="],
 
     "@fastify/websocket": ["@fastify/websocket@11.0.1", "", { "dependencies": { "duplexify": "^4.1.3", "fastify-plugin": "^5.0.0", "ws": "^8.16.0" } }, "sha512-44yam5+t1I9v09hWBYO+ezV88+mb9Se2BjgERtzB/68+0mGeTfFkjBeDBe2y+ZdiPpeO2rhevhdnfrBm5mqH+Q=="],
+
+    "@grammyjs/types": ["@grammyjs/types@3.26.0", "", {}, "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
@@ -308,6 +311,8 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
@@ -428,6 +433,8 @@
 
     "evalite": ["evalite@0.11.6", "", { "dependencies": { "@fastify/static": "^8.0.3", "@fastify/websocket": "11.0.1", "@stricli/auto-complete": "^1.1.1", "@stricli/core": "^1.1.1", "@vitest/runner": "^2.1.8", "better-sqlite3": "^11.6.0", "fastify": "^5.1.0", "file-type": "^19.6.0", "table": "^6.8.2", "tinyrainbow": "^1.2.0" }, "bin": { "evalite": "dist/bin.js" } }, "sha512-o60kE3Lrr6Vz7NmEuefstM2hTXYLcPZqIRjJOF1auSv475JgCzhG59qWShSZxO+DiKdwlPPM6VWmMf3MgeQymw=="],
 
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
@@ -491,6 +498,8 @@
     "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "grammy": ["grammy@1.42.0", "", { "dependencies": { "@grammyjs/types": "3.26.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g=="],
 
     "graphql": ["graphql@16.13.2", "", {}, "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig=="],
 
@@ -587,6 +596,8 @@
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -774,6 +785,8 @@
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
@@ -801,6 +814,10 @@
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
     "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,6 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@supabase/supabase-js": "^2.39.0",
         "ai": "^5.0.0",
-        "grammy": "^1.42.0",
         "hono": "^4.0.0",
         "jose": "^5.9.0",
         "zod": "^4.4.3",
@@ -162,8 +161,6 @@
     "@fastify/static": ["@fastify/static@8.3.0", "", { "dependencies": { "@fastify/accept-negotiator": "^2.0.0", "@fastify/send": "^4.0.0", "content-disposition": "^0.5.4", "fastify-plugin": "^5.0.0", "fastq": "^1.17.1", "glob": "^11.0.0" } }, "sha512-yKxviR5PH1OKNnisIzZKmgZSus0r2OZb8qCSbqmw34aolT4g3UlzYfeBRym+HJ1J471CR8e2ldNub4PubD1coA=="],
 
     "@fastify/websocket": ["@fastify/websocket@11.0.1", "", { "dependencies": { "duplexify": "^4.1.3", "fastify-plugin": "^5.0.0", "ws": "^8.16.0" } }, "sha512-44yam5+t1I9v09hWBYO+ezV88+mb9Se2BjgERtzB/68+0mGeTfFkjBeDBe2y+ZdiPpeO2rhevhdnfrBm5mqH+Q=="],
-
-    "@grammyjs/types": ["@grammyjs/types@3.26.0", "", {}, "sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
@@ -311,8 +308,6 @@
 
     "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 
-    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
-
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
@@ -433,8 +428,6 @@
 
     "evalite": ["evalite@0.11.6", "", { "dependencies": { "@fastify/static": "^8.0.3", "@fastify/websocket": "11.0.1", "@stricli/auto-complete": "^1.1.1", "@stricli/core": "^1.1.1", "@vitest/runner": "^2.1.8", "better-sqlite3": "^11.6.0", "fastify": "^5.1.0", "file-type": "^19.6.0", "table": "^6.8.2", "tinyrainbow": "^1.2.0" }, "bin": { "evalite": "dist/bin.js" } }, "sha512-o60kE3Lrr6Vz7NmEuefstM2hTXYLcPZqIRjJOF1auSv475JgCzhG59qWShSZxO+DiKdwlPPM6VWmMf3MgeQymw=="],
 
-    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
-
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
@@ -498,8 +491,6 @@
     "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
-    "grammy": ["grammy@1.42.0", "", { "dependencies": { "@grammyjs/types": "3.26.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-1AdCge+AkjSdp2FwfICSFnVbl8Mq3KVHJDy+DgTI9+D6keJ0zWALPRKas5jv/8psiCzL4N2cEOcGW7O45Kn39g=="],
 
     "graphql": ["graphql@16.13.2", "", {}, "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig=="],
 
@@ -596,8 +587,6 @@
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
-
-    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -785,8 +774,6 @@
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
@@ -814,10 +801,6 @@
     "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
 
     "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
-
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -19,7 +19,6 @@
 		"@modelcontextprotocol/sdk": "^1.0.0",
 		"@supabase/supabase-js": "^2.39.0",
 		"ai": "^5.0.0",
-		"grammy": "^1.42.0",
 		"hono": "^4.0.0",
 		"jose": "^5.9.0",
 		"zod": "^4.4.3"

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -14,14 +14,15 @@
 	},
 	"dependencies": {
 		"@ai-sdk/anthropic": "^2.0.0",
+		"@hono/zod-validator": "^0.7.6",
 		"@matchmaker/shared": "workspace:*",
 		"@modelcontextprotocol/sdk": "^1.0.0",
 		"@supabase/supabase-js": "^2.39.0",
 		"ai": "^5.0.0",
+		"grammy": "^1.42.0",
 		"hono": "^4.0.0",
 		"jose": "^5.9.0",
-		"zod": "^4.4.3",
-		"@hono/zod-validator": "^0.7.6"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.0.0",

--- a/gateway/src/adapters/index.ts
+++ b/gateway/src/adapters/index.ts
@@ -5,3 +5,5 @@ export type AdapterRegistry = Map<string, ChatAdapter>
 export function createAdapterRegistry(): AdapterRegistry {
 	return new Map()
 }
+
+export { createTelegramAdapter, type TelegramAdapterOptions } from './telegram'

--- a/gateway/src/adapters/telegram/adapter.ts
+++ b/gateway/src/adapters/telegram/adapter.ts
@@ -1,4 +1,7 @@
-import type { ChatAdapter } from '../../types/adapter'
+import { timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
+import type { ChatAdapter, WebhookVerificationInput } from '../../types/adapter'
+import type { OutboundMessage, RawInboundMessage } from '../../types/messages'
 import type { UserMappingService } from '../../services/user-mapping'
 
 export type TelegramAdapterOptions = {
@@ -8,6 +11,102 @@ export type TelegramAdapterOptions = {
 	fetch?: typeof fetch
 }
 
-export function createTelegramAdapter(_options: TelegramAdapterOptions): ChatAdapter {
-	throw new Error('not implemented')
+const PROVIDER = 'telegram'
+const TELEGRAM_TEXT_LIMIT = 4096
+const SECRET_HEADER = 'x-telegram-bot-api-secret-token'
+const API_BASE = 'https://api.telegram.org'
+
+export class TelegramParseError extends Error {
+	constructor(message: string, public readonly cause?: unknown) {
+		super(message)
+		this.name = 'TelegramParseError'
+	}
+}
+
+let textMessageSchema = z.object({
+	message_id: z.number(),
+	from: z.object({ id: z.number() }),
+	chat: z.object({ id: z.number() }),
+	date: z.number().int().nonnegative(),
+	text: z.string().min(1),
+})
+
+let textUpdateSchema = z
+	.object({
+		update_id: z.number(),
+		message: textMessageSchema,
+	})
+	.passthrough()
+
+function chunkText(text: string, limit: number): string[] {
+	if (text.length <= limit) return [text]
+	let chunks: string[] = []
+	for (let i = 0; i < text.length; i += limit) {
+		chunks.push(text.slice(i, i + limit))
+	}
+	return chunks
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+	let aBuf = Buffer.from(a, 'utf8')
+	let bBuf = Buffer.from(b, 'utf8')
+	if (aBuf.length !== bBuf.length) return false
+	return timingSafeEqual(aBuf, bBuf)
+}
+
+export function createTelegramAdapter(options: TelegramAdapterOptions): ChatAdapter {
+	let { botToken, webhookSecret, userMapping } = options
+	let fetchImpl = options.fetch ?? fetch
+	let sendMessageUrl = `${API_BASE}/bot${botToken}/sendMessage`
+
+	return {
+		provider: PROVIDER,
+
+		async parseInbound(raw: unknown): Promise<RawInboundMessage> {
+			let result = textUpdateSchema.safeParse(raw)
+			if (!result.success) {
+				throw new TelegramParseError(
+					'Telegram update is not a supported text message',
+					result.error,
+				)
+			}
+			let { message } = result.data
+			return {
+				provider: PROVIDER,
+				senderId: String(message.from.id),
+				text: message.text,
+				threadId: String(message.chat.id),
+				timestamp: message.date * 1000,
+			}
+		},
+
+		async verifyWebhook({ headers }: WebhookVerificationInput): Promise<boolean> {
+			let provided = headers.get(SECRET_HEADER)
+			if (provided === null) return false
+			return constantTimeEquals(provided, webhookSecret)
+		},
+
+		async sendReply(message: OutboundMessage): Promise<void> {
+			let chatId = Number(message.threadId)
+			let chunks = chunkText(message.text, TELEGRAM_TEXT_LIMIT)
+			for (let chunk of chunks) {
+				let response = await fetchImpl(sendMessageUrl, {
+					method: 'POST',
+					headers: { 'content-type': 'application/json' },
+					body: JSON.stringify({ chat_id: chatId, text: chunk }),
+				})
+				if (!response.ok) {
+					let detail = await response.text().catch(() => '')
+					throw new Error(
+						`Telegram sendMessage failed: ${response.status} ${response.statusText}${detail ? ` — ${detail}` : ''}`,
+					)
+				}
+			}
+		},
+
+		async resolveUser(senderId: string): Promise<{ userId: string }> {
+			let userId = await userMapping.resolveOrCreate(PROVIDER, senderId)
+			return { userId }
+		},
+	}
 }

--- a/gateway/src/adapters/telegram/adapter.ts
+++ b/gateway/src/adapters/telegram/adapter.ts
@@ -1,0 +1,13 @@
+import type { ChatAdapter } from '../../types/adapter'
+import type { UserMappingService } from '../../services/user-mapping'
+
+export type TelegramAdapterOptions = {
+	botToken: string
+	webhookSecret: string
+	userMapping: UserMappingService
+	fetch?: typeof fetch
+}
+
+export function createTelegramAdapter(_options: TelegramAdapterOptions): ChatAdapter {
+	throw new Error('not implemented')
+}

--- a/gateway/src/adapters/telegram/index.ts
+++ b/gateway/src/adapters/telegram/index.ts
@@ -1,0 +1,1 @@
+export { createTelegramAdapter, type TelegramAdapterOptions } from './adapter'

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 import { createApp } from './app'
+import { createTelegramAdapter } from './adapters/telegram'
 import { processMessage as runAiCore } from './core/ai'
 import { createMcpClient } from './core/mcp-client'
 import { createMatchmakerTools } from './core/tools'
@@ -8,6 +9,8 @@ import {
 	HandleInboundMessage,
 	type ProcessMessage,
 } from './services/handle-inbound-message'
+import { createUserMappingService } from './services/user-mapping'
+import { createSupabaseUserMappingDb } from './store/user-provider-mappings'
 import type { ChatAdapter } from './types/adapter'
 
 function requireEnv(name: string): string {
@@ -22,9 +25,14 @@ let SUPABASE_URL = requireEnv('SUPABASE_URL')
 let SUPABASE_SERVICE_ROLE_KEY = requireEnv('SUPABASE_SERVICE_ROLE_KEY')
 let MCP_BASE_URL = requireEnv('MCP_BASE_URL')
 let SUPABASE_JWT_SECRET = requireEnv('SUPABASE_JWT_SECRET')
+let TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN
+let TELEGRAM_WEBHOOK_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET
 
 let supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 let store = createConversationStore(createSupabaseConversationDb(supabase))
+let userMapping = createUserMappingService({
+	db: createSupabaseUserMappingDb(supabase),
+})
 
 let processMessage: ProcessMessage = async ({ inbound }) => {
 	let caller = createMcpClient({
@@ -38,6 +46,21 @@ let processMessage: ProcessMessage = async ({ inbound }) => {
 
 let service = new HandleInboundMessage({ processMessage })
 let adapters = new Map<string, ChatAdapter>()
+
+if (TELEGRAM_BOT_TOKEN && TELEGRAM_WEBHOOK_SECRET) {
+	adapters.set(
+		'telegram',
+		createTelegramAdapter({
+			botToken: TELEGRAM_BOT_TOKEN,
+			webhookSecret: TELEGRAM_WEBHOOK_SECRET,
+			userMapping,
+		}),
+	)
+} else {
+	console.warn(
+		'Telegram adapter not registered: set TELEGRAM_BOT_TOKEN and TELEGRAM_WEBHOOK_SECRET to enable it.',
+	)
+}
 
 let app = createApp({ adapters, service })
 

--- a/gateway/tests/adapters/telegram/adapter.test.ts
+++ b/gateway/tests/adapters/telegram/adapter.test.ts
@@ -98,7 +98,7 @@ describe('createTelegramAdapter', () => {
 				},
 			}
 
-			expect(adapter.parseInbound(raw)).rejects.toThrow()
+			await expect(adapter.parseInbound(raw)).rejects.toThrow()
 		})
 
 		test('rejects edited_message updates', async () => {
@@ -115,21 +115,21 @@ describe('createTelegramAdapter', () => {
 				},
 			}
 
-			expect(adapter.parseInbound(raw)).rejects.toThrow()
+			await expect(adapter.parseInbound(raw)).rejects.toThrow()
 		})
 
 		test('rejects non-text messages (e.g. status/photo only)', async () => {
 			let adapter = buildAdapter()
 			let raw = validUpdate({ text: undefined, photo: [{ file_id: 'abc', file_unique_id: 'u', width: 1, height: 1 }] })
 
-			expect(adapter.parseInbound(raw)).rejects.toThrow()
+			await expect(adapter.parseInbound(raw)).rejects.toThrow()
 		})
 
 		test('rejects malformed payloads', async () => {
 			let adapter = buildAdapter()
 
-			expect(adapter.parseInbound({ totally: 'bogus' })).rejects.toThrow()
-			expect(adapter.parseInbound(null)).rejects.toThrow()
+			await expect(adapter.parseInbound({ totally: 'bogus' })).rejects.toThrow()
+			await expect(adapter.parseInbound(null)).rejects.toThrow()
 		})
 	})
 
@@ -223,7 +223,7 @@ describe('createTelegramAdapter', () => {
 			)
 			let adapter = buildAdapter({ fetch: fakeFetch })
 
-			expect(
+			await expect(
 				adapter.sendReply({
 					provider: 'telegram',
 					senderId: '123',

--- a/gateway/tests/adapters/telegram/adapter.test.ts
+++ b/gateway/tests/adapters/telegram/adapter.test.ts
@@ -25,12 +25,17 @@ function makeRecordingFetch(
 	respond: (call: FetchCall) => Response = () => new Response('{"ok":true}', { status: 200 }),
 ): { fetch: typeof fetch; calls: FetchCall[] } {
 	let calls: FetchCall[] = []
-	let fakeFetch: typeof fetch = async (input, init) => {
-		let url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url
+	let fakeFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+		let url =
+			typeof input === 'string'
+				? input
+				: input instanceof URL
+					? input.toString()
+					: input.url
 		let call: FetchCall = { url, init }
 		calls.push(call)
 		return respond(call)
-	}
+	}) as unknown as typeof fetch
 	return { fetch: fakeFetch, calls }
 }
 
@@ -231,13 +236,13 @@ describe('createTelegramAdapter', () => {
 		test('sends chunks sequentially (not in parallel)', async () => {
 			let inflight = 0
 			let maxInflight = 0
-			let fakeFetch: typeof fetch = async () => {
+			let fakeFetch = (async () => {
 				inflight++
 				maxInflight = Math.max(maxInflight, inflight)
 				await new Promise(resolve => setTimeout(resolve, 5))
 				inflight--
 				return new Response('{"ok":true}', { status: 200 })
-			}
+			}) as unknown as typeof fetch
 			let adapter = buildAdapter({ fetch: fakeFetch })
 
 			await adapter.sendReply({

--- a/gateway/tests/adapters/telegram/adapter.test.ts
+++ b/gateway/tests/adapters/telegram/adapter.test.ts
@@ -1,0 +1,276 @@
+import { describe, test, expect } from 'bun:test'
+import { createTelegramAdapter } from '../../../src/adapters/telegram'
+import type { UserMappingService } from '../../../src/services/user-mapping'
+
+const BOT_TOKEN = 'test-bot-token'
+const WEBHOOK_SECRET = 'super-secret-token'
+const USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+function makeUserMapping(
+	resolve: (provider: string, senderId: string) => Promise<string> = async () => USER_ID,
+): UserMappingService & { calls: Array<{ provider: string; senderId: string }> } {
+	let calls: Array<{ provider: string; senderId: string }> = []
+	return {
+		calls,
+		async resolveOrCreate(provider, senderId) {
+			calls.push({ provider, senderId })
+			return resolve(provider, senderId)
+		},
+	}
+}
+
+type FetchCall = { url: string; init: RequestInit | undefined }
+
+function makeRecordingFetch(
+	respond: (call: FetchCall) => Response = () => new Response('{"ok":true}', { status: 200 }),
+): { fetch: typeof fetch; calls: FetchCall[] } {
+	let calls: FetchCall[] = []
+	let fakeFetch: typeof fetch = async (input, init) => {
+		let url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url
+		let call: FetchCall = { url, init }
+		calls.push(call)
+		return respond(call)
+	}
+	return { fetch: fakeFetch, calls }
+}
+
+function buildAdapter(opts: {
+	userMapping?: UserMappingService
+	fetch?: typeof fetch
+} = {}) {
+	return createTelegramAdapter({
+		botToken: BOT_TOKEN,
+		webhookSecret: WEBHOOK_SECRET,
+		userMapping: opts.userMapping ?? makeUserMapping(),
+		fetch: opts.fetch,
+	})
+}
+
+function validUpdate(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		update_id: 1,
+		message: {
+			message_id: 10,
+			from: { id: 123, is_bot: false, first_name: 'Alice' },
+			chat: { id: 456, type: 'private', first_name: 'Alice' },
+			date: 1_700_000_000,
+			text: 'Hello',
+			...overrides,
+		},
+	}
+}
+
+describe('createTelegramAdapter', () => {
+	test('exposes provider="telegram"', () => {
+		let adapter = buildAdapter()
+		expect(adapter.provider).toBe('telegram')
+	})
+
+	describe('parseInbound', () => {
+		test('parses a valid text Telegram update into a RawInboundMessage', async () => {
+			let adapter = buildAdapter()
+
+			let parsed = await adapter.parseInbound(validUpdate())
+
+			expect(parsed).toEqual({
+				provider: 'telegram',
+				senderId: '123',
+				text: 'Hello',
+				threadId: '456',
+				timestamp: 1_700_000_000_000,
+			})
+		})
+
+		test('rejects callback_query updates', async () => {
+			let adapter = buildAdapter()
+			let raw = {
+				update_id: 2,
+				callback_query: {
+					id: 'cb-1',
+					from: { id: 123, is_bot: false, first_name: 'Alice' },
+					chat_instance: 'inst-1',
+					data: 'noop',
+				},
+			}
+
+			expect(adapter.parseInbound(raw)).rejects.toThrow()
+		})
+
+		test('rejects edited_message updates', async () => {
+			let adapter = buildAdapter()
+			let raw = {
+				update_id: 3,
+				edited_message: {
+					message_id: 10,
+					from: { id: 123, is_bot: false, first_name: 'Alice' },
+					chat: { id: 456, type: 'private', first_name: 'Alice' },
+					date: 1_700_000_000,
+					edit_date: 1_700_000_010,
+					text: 'edited',
+				},
+			}
+
+			expect(adapter.parseInbound(raw)).rejects.toThrow()
+		})
+
+		test('rejects non-text messages (e.g. status/photo only)', async () => {
+			let adapter = buildAdapter()
+			let raw = validUpdate({ text: undefined, photo: [{ file_id: 'abc', file_unique_id: 'u', width: 1, height: 1 }] })
+
+			expect(adapter.parseInbound(raw)).rejects.toThrow()
+		})
+
+		test('rejects malformed payloads', async () => {
+			let adapter = buildAdapter()
+
+			expect(adapter.parseInbound({ totally: 'bogus' })).rejects.toThrow()
+			expect(adapter.parseInbound(null)).rejects.toThrow()
+		})
+	})
+
+	describe('verifyWebhook', () => {
+		test('returns true when X-Telegram-Bot-Api-Secret-Token matches', async () => {
+			let adapter = buildAdapter()
+			let headers = new Headers({ 'X-Telegram-Bot-Api-Secret-Token': WEBHOOK_SECRET })
+
+			let ok = await adapter.verifyWebhook({ headers, body: new ArrayBuffer(0) })
+
+			expect(ok).toBe(true)
+		})
+
+		test('returns false when the header is wrong', async () => {
+			let adapter = buildAdapter()
+			let headers = new Headers({ 'X-Telegram-Bot-Api-Secret-Token': 'nope' })
+
+			let ok = await adapter.verifyWebhook({ headers, body: new ArrayBuffer(0) })
+
+			expect(ok).toBe(false)
+		})
+
+		test('returns false when the header is missing', async () => {
+			let adapter = buildAdapter()
+
+			let ok = await adapter.verifyWebhook({ headers: new Headers(), body: new ArrayBuffer(0) })
+
+			expect(ok).toBe(false)
+		})
+
+		test('returns false when the header has the right prefix but a longer suffix', async () => {
+			let adapter = buildAdapter()
+			let headers = new Headers({
+				'X-Telegram-Bot-Api-Secret-Token': WEBHOOK_SECRET + 'x',
+			})
+
+			let ok = await adapter.verifyWebhook({ headers, body: new ArrayBuffer(0) })
+
+			expect(ok).toBe(false)
+		})
+	})
+
+	describe('sendReply', () => {
+		test('POSTs to the Telegram Bot API sendMessage endpoint with chat_id and text', async () => {
+			let { fetch: fakeFetch, calls } = makeRecordingFetch()
+			let adapter = buildAdapter({ fetch: fakeFetch })
+
+			await adapter.sendReply({
+				provider: 'telegram',
+				senderId: '123',
+				threadId: '456',
+				text: 'Hi there',
+			})
+
+			expect(calls).toHaveLength(1)
+			expect(calls[0]!.url).toBe(`https://api.telegram.org/bot${BOT_TOKEN}/sendMessage`)
+			expect(calls[0]!.init?.method).toBe('POST')
+			let headers = new Headers(calls[0]!.init?.headers)
+			expect(headers.get('content-type')).toBe('application/json')
+			let body = JSON.parse(calls[0]!.init!.body as string) as { chat_id: number; text: string }
+			expect(body.chat_id).toBe(456)
+			expect(body.text).toBe('Hi there')
+		})
+
+		test('chunks text longer than 4096 characters into ordered messages', async () => {
+			let { fetch: fakeFetch, calls } = makeRecordingFetch()
+			let adapter = buildAdapter({ fetch: fakeFetch })
+
+			let chunkA = 'a'.repeat(4096)
+			let chunkB = 'b'.repeat(4096)
+			let chunkC = 'c'.repeat(100)
+			let text = chunkA + chunkB + chunkC
+
+			await adapter.sendReply({
+				provider: 'telegram',
+				senderId: '123',
+				threadId: '456',
+				text,
+			})
+
+			expect(calls).toHaveLength(3)
+			let bodies = calls.map(c => JSON.parse(c.init!.body as string) as { text: string })
+			expect(bodies[0]!.text).toBe(chunkA)
+			expect(bodies[1]!.text).toBe(chunkB)
+			expect(bodies[2]!.text).toBe(chunkC)
+		})
+
+		test('throws on a non-2xx response', async () => {
+			let { fetch: fakeFetch } = makeRecordingFetch(
+				() => new Response('{"ok":false,"description":"bad"}', { status: 400 }),
+			)
+			let adapter = buildAdapter({ fetch: fakeFetch })
+
+			expect(
+				adapter.sendReply({
+					provider: 'telegram',
+					senderId: '123',
+					threadId: '456',
+					text: 'Hi',
+				}),
+			).rejects.toThrow()
+		})
+
+		test('sends chunks sequentially (not in parallel)', async () => {
+			let inflight = 0
+			let maxInflight = 0
+			let fakeFetch: typeof fetch = async () => {
+				inflight++
+				maxInflight = Math.max(maxInflight, inflight)
+				await new Promise(resolve => setTimeout(resolve, 5))
+				inflight--
+				return new Response('{"ok":true}', { status: 200 })
+			}
+			let adapter = buildAdapter({ fetch: fakeFetch })
+
+			await adapter.sendReply({
+				provider: 'telegram',
+				senderId: '123',
+				threadId: '456',
+				text: 'a'.repeat(4096) + 'b'.repeat(4096),
+			})
+
+			expect(maxInflight).toBe(1)
+		})
+	})
+
+	describe('resolveUser', () => {
+		test('first-time call delegates to UserMappingService.resolveOrCreate and returns the uuid', async () => {
+			let userMapping = makeUserMapping()
+			let adapter = buildAdapter({ userMapping })
+
+			let result = await adapter.resolveUser('123')
+
+			expect(result).toEqual({ userId: USER_ID })
+			expect(userMapping.calls).toEqual([{ provider: 'telegram', senderId: '123' }])
+		})
+
+		test('returning user goes through the same delegation with provider="telegram"', async () => {
+			let existingId = 'existing-uuid-1234'
+			let userMapping = makeUserMapping(async () => existingId)
+			let adapter = buildAdapter({ userMapping })
+
+			let result = await adapter.resolveUser('99999')
+
+			expect(result).toEqual({ userId: existingId })
+			expect(userMapping.calls).toEqual([{ provider: 'telegram', senderId: '99999' }])
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Adds `gateway/src/adapters/telegram/` implementing `ChatAdapter` for `provider: 'telegram'`: Zod-validated `parseInbound` (text-only updates), constant-time `verifyWebhook` against `X-Telegram-Bot-Api-Secret-Token`, `sendReply` that POSTs to the Bot API and chunks payloads above the 4096-char ceiling sequentially, and `resolveUser` delegating to `UserMappingService.resolveOrCreate('telegram', ...)`.
- Wires the adapter into `gateway/src/index.ts`. The Supabase-backed `UserMappingService` is constructed once and injected.

## Decisions

- **Non-text updates**: `parseInbound` rejects callback queries, edited messages, channel posts, and media-only messages with a typed `TelegramParseError`. The orchestrator wraps this in `InboundParseError` so the router returns HTTP 400. We do not silently no-op on these — the router responds, but no reply is sent.
- **Env handling for Telegram credentials**: the Telegram credentials are read from `process.env.*` directly (not `requireEnv`). When either `TELEGRAM_BOT_TOKEN` or `TELEGRAM_WEBHOOK_SECRET` is missing the adapter is skipped with a warning. This keeps local dev able to boot the gateway without provider creds while we wait for the dedicated config module from Step 9 (#94 / separate issue) to centralize required env handling.
- **`fetch` injection**: the factory accepts an optional `fetch` so unit tests record HTTP calls without globally patching fetch. In production we fall through to the global `fetch`.
- **No grammY dependency**: parsing is done with a focused Zod schema for the text-message shape rather than pulling in `grammy`/`@grammyjs/types`. The Bot API surface we use is small (`POST /bot<token>/sendMessage` and the `X-Telegram-Bot-Api-Secret-Token` header), so a hand-rolled schema + `fetch` keeps validation strict, lets us issue clean errors for unsupported updates, and avoids Telegram's massive type tree and grammY's transitive deps (`@grammyjs/types`, `node-fetch`, `abort-controller`, `whatwg-url`) in the runtime contract.

## Test plan

- [x] `bun test` from `gateway/` (106 pass, including 16 adapter tests covering parse happy path, callback_query / edited_message / non-text / malformed rejection, secret-token verify (correct, wrong, missing, suffix-extended), `sendReply` URL/body/method, 4096-char chunking, sequential ordering, non-2xx error, and `resolveUser` first-time + returning delegations — all six rejection assertions are now properly awaited)
- [x] `bun run typecheck` from `gateway/`
- [x] Repo-root `bun run test` (gateway + backend + mcp + shared all green)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)