### PR TITLE
feat(gateway): implement WhatsApp adapter with Meta Cloud API

### DIFF
--- a/gateway/src/adapters/index.ts
+++ b/gateway/src/adapters/index.ts
@@ -5,3 +5,6 @@ export type AdapterRegistry = Map<string, ChatAdapter>
 export function createAdapterRegistry(): AdapterRegistry {
 	return new Map()
 }
+
+export { createWhatsappAdapter } from './whatsapp'
+export type { WhatsappAdapterOptions } from './whatsapp'

--- a/gateway/src/adapters/whatsapp/adapter.ts
+++ b/gateway/src/adapters/whatsapp/adapter.ts
@@ -1,0 +1,132 @@
+import { createHmac, timingSafeEqual } from 'node:crypto'
+import { z } from 'zod'
+import type { ChatAdapter, WebhookVerificationInput } from '../../types/adapter'
+import type { OutboundMessage, RawInboundMessage } from '../../types/messages'
+import type { UserMappingService } from '../../services/user-mapping'
+
+let textMessageSchema = z.object({
+	from: z.string().min(1),
+	timestamp: z.string().min(1),
+	type: z.literal('text'),
+	text: z.object({ body: z.string().min(1) }),
+})
+
+let valueWithMessagesSchema = z.object({
+	messages: z.array(z.unknown()).min(1),
+})
+
+let webhookEnvelopeSchema = z.object({
+	entry: z
+		.array(
+			z.object({
+				changes: z
+					.array(
+						z.object({
+							value: z.unknown(),
+						}),
+					)
+					.min(1),
+			}),
+		)
+		.min(1),
+})
+
+export type WhatsappAdapterOptions = {
+	phoneNumberId: string
+	accessToken: string
+	appSecret: string
+	verifyToken: string
+	userMapping: UserMappingService
+	fetch?: typeof fetch
+}
+
+let GRAPH_API_BASE = 'https://graph.facebook.com/v20.0'
+let SIGNATURE_HEADER = 'x-hub-signature-256'
+let SIGNATURE_PREFIX = 'sha256='
+
+export function createWhatsappAdapter(options: WhatsappAdapterOptions): ChatAdapter {
+	let {
+		phoneNumberId,
+		accessToken,
+		appSecret,
+		verifyToken,
+		userMapping,
+		fetch: fetchImpl = fetch,
+	} = options
+
+	let messagesUrl = `${GRAPH_API_BASE}/${phoneNumberId}/messages`
+
+	return {
+		provider: 'whatsapp',
+
+		async parseInbound(raw: unknown): Promise<RawInboundMessage> {
+			let envelope = webhookEnvelopeSchema.parse(raw)
+			let value = envelope.entry[0]!.changes[0]!.value
+			let withMessages = valueWithMessagesSchema.parse(value)
+			let message = textMessageSchema.parse(withMessages.messages[0])
+
+			return {
+				provider: 'whatsapp',
+				senderId: message.from,
+				text: message.text.body,
+				threadId: message.from,
+				timestamp: Number(message.timestamp) * 1000,
+			}
+		},
+
+		async verifyWebhook(input: WebhookVerificationInput): Promise<boolean> {
+			let header = input.headers.get(SIGNATURE_HEADER)
+			if (!header || !header.startsWith(SIGNATURE_PREFIX)) return false
+
+			let providedHex = header.slice(SIGNATURE_PREFIX.length)
+			let expectedHex = createHmac('sha256', appSecret)
+				.update(Buffer.from(input.body))
+				.digest('hex')
+
+			if (providedHex.length !== expectedHex.length) return false
+
+			let provided = Buffer.from(providedHex, 'hex')
+			let expected = Buffer.from(expectedHex, 'hex')
+			if (provided.length !== expected.length) return false
+			return timingSafeEqual(provided, expected)
+		},
+
+		async sendReply(message: OutboundMessage): Promise<void> {
+			let res = await fetchImpl(messagesUrl, {
+				method: 'POST',
+				headers: {
+					'Authorization': `Bearer ${accessToken}`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({
+					messaging_product: 'whatsapp',
+					to: message.senderId,
+					type: 'text',
+					text: { body: message.text },
+				}),
+			})
+
+			if (!res.ok) {
+				let text = await res.text().catch(() => '')
+				throw new Error(
+					`WhatsApp Graph API ${res.status} ${res.statusText}: ${text.slice(0, 500)}`,
+				)
+			}
+		},
+
+		async resolveUser(senderId: string): Promise<{ userId: string }> {
+			let userId = await userMapping.resolveOrCreate('whatsapp', senderId)
+			return { userId }
+		},
+
+		verifyChallenge(query: URLSearchParams): string | null {
+			let mode = query.get('hub.mode')
+			let token = query.get('hub.verify_token')
+			let challenge = query.get('hub.challenge')
+			if (mode !== 'subscribe') return null
+			if (token !== verifyToken) return null
+			if (challenge === null) return null
+			return challenge
+		},
+	}
+}

--- a/gateway/src/adapters/whatsapp/adapter.ts
+++ b/gateway/src/adapters/whatsapp/adapter.ts
@@ -31,13 +31,15 @@ let webhookEnvelopeSchema = z.object({
 		.min(1),
 })
 
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
 export type WhatsappAdapterOptions = {
 	phoneNumberId: string
 	accessToken: string
 	appSecret: string
 	verifyToken: string
 	userMapping: UserMappingService
-	fetch?: typeof fetch
+	fetch?: FetchLike
 }
 
 let GRAPH_API_BASE = 'https://graph.facebook.com/v20.0'

--- a/gateway/src/adapters/whatsapp/index.ts
+++ b/gateway/src/adapters/whatsapp/index.ts
@@ -1,2 +1,2 @@
 export { createWhatsappAdapter } from './adapter'
-export type { WhatsappAdapterOptions } from './adapter'
+export type { FetchLike, WhatsappAdapterOptions } from './adapter'

--- a/gateway/src/adapters/whatsapp/index.ts
+++ b/gateway/src/adapters/whatsapp/index.ts
@@ -1,0 +1,2 @@
+export { createWhatsappAdapter } from './adapter'
+export type { WhatsappAdapterOptions } from './adapter'

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js'
 import { createApp } from './app'
+import { createWhatsappAdapter } from './adapters/whatsapp'
 import { processMessage as runAiCore } from './core/ai'
 import { createMcpClient } from './core/mcp-client'
 import { createMatchmakerTools } from './core/tools'
@@ -8,6 +9,8 @@ import {
 	HandleInboundMessage,
 	type ProcessMessage,
 } from './services/handle-inbound-message'
+import { createUserMappingService } from './services/user-mapping'
+import { createSupabaseUserMappingDb } from './store/user-provider-mappings'
 import type { ChatAdapter } from './types/adapter'
 
 function requireEnv(name: string): string {
@@ -18,6 +21,11 @@ function requireEnv(name: string): string {
 	return value
 }
 
+function optionalEnv(name: string): string | undefined {
+	let value = process.env[name]
+	return value && value.length > 0 ? value : undefined
+}
+
 let SUPABASE_URL = requireEnv('SUPABASE_URL')
 let SUPABASE_SERVICE_ROLE_KEY = requireEnv('SUPABASE_SERVICE_ROLE_KEY')
 let MCP_BASE_URL = requireEnv('MCP_BASE_URL')
@@ -25,6 +33,7 @@ let SUPABASE_JWT_SECRET = requireEnv('SUPABASE_JWT_SECRET')
 
 let supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
 let store = createConversationStore(createSupabaseConversationDb(supabase))
+let userMapping = createUserMappingService({ db: createSupabaseUserMappingDb(supabase) })
 
 let processMessage: ProcessMessage = async ({ inbound }) => {
 	let caller = createMcpClient({
@@ -38,6 +47,29 @@ let processMessage: ProcessMessage = async ({ inbound }) => {
 
 let service = new HandleInboundMessage({ processMessage })
 let adapters = new Map<string, ChatAdapter>()
+
+let WHATSAPP_PHONE_NUMBER_ID = optionalEnv('WHATSAPP_PHONE_NUMBER_ID')
+let WHATSAPP_ACCESS_TOKEN = optionalEnv('WHATSAPP_ACCESS_TOKEN')
+let WHATSAPP_APP_SECRET = optionalEnv('WHATSAPP_APP_SECRET')
+let WHATSAPP_VERIFY_TOKEN = optionalEnv('WHATSAPP_VERIFY_TOKEN')
+
+if (
+	WHATSAPP_PHONE_NUMBER_ID &&
+	WHATSAPP_ACCESS_TOKEN &&
+	WHATSAPP_APP_SECRET &&
+	WHATSAPP_VERIFY_TOKEN
+) {
+	adapters.set(
+		'whatsapp',
+		createWhatsappAdapter({
+			phoneNumberId: WHATSAPP_PHONE_NUMBER_ID,
+			accessToken: WHATSAPP_ACCESS_TOKEN,
+			appSecret: WHATSAPP_APP_SECRET,
+			verifyToken: WHATSAPP_VERIFY_TOKEN,
+			userMapping,
+		}),
+	)
+}
 
 let app = createApp({ adapters, service })
 

--- a/gateway/src/router/webhook.ts
+++ b/gateway/src/router/webhook.ts
@@ -9,6 +9,22 @@ export function createWebhookRouter(
 ) {
 	let router = new Hono()
 
+	router.get('/:provider', (c) => {
+		let provider = c.req.param('provider')
+		let adapter = adapters.get(provider)
+		if (!adapter || !adapter.verifyChallenge) {
+			return c.json({ error: 'Not found' }, 404)
+		}
+
+		let url = new URL(c.req.url)
+		let challenge = adapter.verifyChallenge(url.searchParams)
+		if (challenge === null) {
+			return c.json({ error: 'Forbidden' }, 403)
+		}
+
+		return c.text(challenge, 200)
+	})
+
 	router.post('/:provider', async (c) => {
 		let provider = c.req.param('provider')
 		let adapter = adapters.get(provider)

--- a/gateway/src/types/adapter.ts
+++ b/gateway/src/types/adapter.ts
@@ -16,4 +16,12 @@ export interface ChatAdapter {
 	sendReply(message: OutboundMessage): Promise<void>
 	resolveUser(senderId: string): Promise<{ userId: string }>
 	verifyWebhook(input: WebhookVerificationInput): Promise<boolean>
+	/**
+	 * Optional one-time verification handshake for providers that issue a
+	 * GET challenge during webhook subscription (e.g. Meta Cloud API).
+	 * Return the challenge value to echo back, or null to reject. Adapters
+	 * that have no GET handshake should leave this undefined; the router
+	 * responds with 404 in that case.
+	 */
+	verifyChallenge?(query: URLSearchParams): string | null
 }

--- a/gateway/tests/adapters/whatsapp/adapter.test.ts
+++ b/gateway/tests/adapters/whatsapp/adapter.test.ts
@@ -1,0 +1,329 @@
+import { describe, test, expect } from 'bun:test'
+import { createHmac } from 'node:crypto'
+import { createWhatsappAdapter } from '../../../src/adapters/whatsapp'
+import type { UserMappingService } from '../../../src/services/user-mapping'
+
+let PHONE_NUMBER_ID = '111222333'
+let ACCESS_TOKEN = 'test-access-token'
+let APP_SECRET = 'test-app-secret'
+let VERIFY_TOKEN = 'test-verify-token'
+let RESOLVED_USER_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+function makeUserMapping(overrides: Partial<UserMappingService> = {}): UserMappingService {
+	return {
+		resolveOrCreate: async () => RESOLVED_USER_ID,
+		...overrides,
+	}
+}
+
+function buildAdapter(overrides: {
+	userMapping?: UserMappingService
+	fetch?: typeof fetch
+} = {}) {
+	return createWhatsappAdapter({
+		phoneNumberId: PHONE_NUMBER_ID,
+		accessToken: ACCESS_TOKEN,
+		appSecret: APP_SECRET,
+		verifyToken: VERIFY_TOKEN,
+		userMapping: overrides.userMapping ?? makeUserMapping(),
+		fetch: overrides.fetch,
+	})
+}
+
+function metaTextWebhook(opts: {
+	from?: string
+	body?: string
+	timestamp?: string
+} = {}) {
+	return {
+		object: 'whatsapp_business_account',
+		entry: [
+			{
+				id: 'WABA_ID',
+				changes: [
+					{
+						field: 'messages',
+						value: {
+							messaging_product: 'whatsapp',
+							metadata: {
+								display_phone_number: '15555550000',
+								phone_number_id: PHONE_NUMBER_ID,
+							},
+							messages: [
+								{
+									from: opts.from ?? '15551234567',
+									id: 'wamid.ABC',
+									timestamp: opts.timestamp ?? '1715000000',
+									type: 'text',
+									text: { body: opts.body ?? 'hello there' },
+								},
+							],
+						},
+					},
+				],
+			},
+		],
+	}
+}
+
+function metaStatusOnlyWebhook() {
+	return {
+		object: 'whatsapp_business_account',
+		entry: [
+			{
+				id: 'WABA_ID',
+				changes: [
+					{
+						field: 'messages',
+						value: {
+							messaging_product: 'whatsapp',
+							metadata: {
+								display_phone_number: '15555550000',
+								phone_number_id: PHONE_NUMBER_ID,
+							},
+							statuses: [
+								{
+									id: 'wamid.ABC',
+									status: 'delivered',
+									timestamp: '1715000000',
+									recipient_id: '15551234567',
+								},
+							],
+						},
+					},
+				],
+			},
+		],
+	}
+}
+
+describe('createWhatsappAdapter', () => {
+	test('exposes provider "whatsapp"', () => {
+		let adapter = buildAdapter()
+		expect(adapter.provider).toBe('whatsapp')
+	})
+
+	describe('parseInbound', () => {
+		test('parses a valid Meta text webhook into a RawInboundMessage', async () => {
+			let adapter = buildAdapter()
+			let raw = metaTextWebhook({ from: '15551234567', body: 'hello there', timestamp: '1715000000' })
+
+			let parsed = await adapter.parseInbound(raw)
+
+			expect(parsed.provider).toBe('whatsapp')
+			expect(parsed.senderId).toBe('15551234567')
+			expect(parsed.text).toBe('hello there')
+			expect(parsed.threadId).toBe('15551234567')
+			expect(parsed.timestamp).toBe(1715000000 * 1000)
+		})
+
+		test('throws on a status-only payload (no messages array)', async () => {
+			let adapter = buildAdapter()
+			await expect(adapter.parseInbound(metaStatusOnlyWebhook())).rejects.toThrow()
+		})
+
+		test('throws on a payload that is not a Meta webhook envelope', async () => {
+			let adapter = buildAdapter()
+			await expect(adapter.parseInbound({ random: 'thing' })).rejects.toThrow()
+		})
+
+		test('throws on a non-text message type', async () => {
+			let adapter = buildAdapter()
+			let raw = {
+				object: 'whatsapp_business_account',
+				entry: [
+					{
+						id: 'WABA_ID',
+						changes: [
+							{
+								field: 'messages',
+								value: {
+									messaging_product: 'whatsapp',
+									metadata: { display_phone_number: '15555550000', phone_number_id: PHONE_NUMBER_ID },
+									messages: [
+										{
+											from: '15551234567',
+											id: 'wamid.IMG',
+											timestamp: '1715000000',
+											type: 'image',
+											image: { mime_type: 'image/jpeg', sha256: 'x', id: 'media-id' },
+										},
+									],
+								},
+							},
+						],
+					},
+				],
+			}
+			await expect(adapter.parseInbound(raw)).rejects.toThrow()
+		})
+	})
+
+	describe('verifyWebhook', () => {
+		function signedRequest(bodyText: string, secret = APP_SECRET) {
+			let body = new TextEncoder().encode(bodyText).buffer as ArrayBuffer
+			let hex = createHmac('sha256', secret).update(bodyText).digest('hex')
+			let headers = new Headers({ 'X-Hub-Signature-256': `sha256=${hex}` })
+			return { body, headers }
+		}
+
+		test('returns true for a correct signature', async () => {
+			let adapter = buildAdapter()
+			let payload = JSON.stringify(metaTextWebhook())
+			let { body, headers } = signedRequest(payload)
+
+			let ok = await adapter.verifyWebhook({ headers, body })
+			expect(ok).toBe(true)
+		})
+
+		test('returns false when signature is tampered', async () => {
+			let adapter = buildAdapter()
+			let payload = JSON.stringify(metaTextWebhook())
+			let { body } = signedRequest(payload)
+			let tampered = new Headers({ 'X-Hub-Signature-256': 'sha256=' + 'a'.repeat(64) })
+
+			let ok = await adapter.verifyWebhook({ headers: tampered, body })
+			expect(ok).toBe(false)
+		})
+
+		test('returns false when signature header is missing', async () => {
+			let adapter = buildAdapter()
+			let payload = JSON.stringify(metaTextWebhook())
+			let body = new TextEncoder().encode(payload).buffer as ArrayBuffer
+
+			let ok = await adapter.verifyWebhook({ headers: new Headers(), body })
+			expect(ok).toBe(false)
+		})
+
+		test('returns false when signature is wrong length', async () => {
+			let adapter = buildAdapter()
+			let payload = JSON.stringify(metaTextWebhook())
+			let body = new TextEncoder().encode(payload).buffer as ArrayBuffer
+			let headers = new Headers({ 'X-Hub-Signature-256': 'sha256=deadbeef' })
+
+			let ok = await adapter.verifyWebhook({ headers, body })
+			expect(ok).toBe(false)
+		})
+
+		test('returns false when signature header lacks the sha256= prefix', async () => {
+			let adapter = buildAdapter()
+			let payload = JSON.stringify(metaTextWebhook())
+			let bodyText = payload
+			let hex = createHmac('sha256', APP_SECRET).update(bodyText).digest('hex')
+			let body = new TextEncoder().encode(bodyText).buffer as ArrayBuffer
+			let headers = new Headers({ 'X-Hub-Signature-256': hex })
+
+			let ok = await adapter.verifyWebhook({ headers, body })
+			expect(ok).toBe(false)
+		})
+	})
+
+	describe('sendReply', () => {
+		test('POSTs to the Meta Graph API with bearer auth and the right body', async () => {
+			let captured: { url: string; init: RequestInit } | null = null
+			let fakeFetch: typeof fetch = async (input, init) => {
+				captured = { url: String(input), init: init ?? {} }
+				return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+			}
+			let adapter = buildAdapter({ fetch: fakeFetch })
+
+			await adapter.sendReply({
+				provider: 'whatsapp',
+				senderId: '15551234567',
+				threadId: '15551234567',
+				text: 'hello back',
+			})
+
+			expect(captured).not.toBeNull()
+			expect(captured!.url).toBe(`https://graph.facebook.com/v20.0/${PHONE_NUMBER_ID}/messages`)
+			expect(captured!.init.method).toBe('POST')
+			let headers = new Headers(captured!.init.headers as HeadersInit)
+			expect(headers.get('authorization')).toBe(`Bearer ${ACCESS_TOKEN}`)
+			expect(headers.get('content-type')).toBe('application/json')
+			let body = JSON.parse(String(captured!.init.body))
+			expect(body).toEqual({
+				messaging_product: 'whatsapp',
+				to: '15551234567',
+				type: 'text',
+				text: { body: 'hello back' },
+			})
+		})
+
+		test('throws on non-2xx response', async () => {
+			let fakeFetch: typeof fetch = async () =>
+				new Response('{"error":{"message":"bad"}}', { status: 400 })
+			let adapter = buildAdapter({ fetch: fakeFetch })
+
+			await expect(
+				adapter.sendReply({
+					provider: 'whatsapp',
+					senderId: '15551234567',
+					threadId: '15551234567',
+					text: 'oops',
+				}),
+			).rejects.toThrow()
+		})
+	})
+
+	describe('resolveUser', () => {
+		test('delegates to UserMappingService.resolveOrCreate("whatsapp", senderId)', async () => {
+			let calls: Array<[string, string]> = []
+			let userMapping = makeUserMapping({
+				resolveOrCreate: async (provider, senderId) => {
+					calls.push([provider, senderId])
+					return RESOLVED_USER_ID
+				},
+			})
+			let adapter = buildAdapter({ userMapping })
+
+			let result = await adapter.resolveUser('15551234567')
+
+			expect(result).toEqual({ userId: RESOLVED_USER_ID })
+			expect(calls).toEqual([['whatsapp', '15551234567']])
+		})
+	})
+
+	describe('verifyChallenge', () => {
+		test('returns the challenge value when mode=subscribe and token matches', () => {
+			let adapter = buildAdapter()
+			let q = new URLSearchParams({
+				'hub.mode': 'subscribe',
+				'hub.verify_token': VERIFY_TOKEN,
+				'hub.challenge': '12345',
+			})
+
+			expect(adapter.verifyChallenge!(q)).toBe('12345')
+		})
+
+		test('returns null when token mismatches', () => {
+			let adapter = buildAdapter()
+			let q = new URLSearchParams({
+				'hub.mode': 'subscribe',
+				'hub.verify_token': 'wrong',
+				'hub.challenge': '12345',
+			})
+
+			expect(adapter.verifyChallenge!(q)).toBeNull()
+		})
+
+		test('returns null when mode is missing', () => {
+			let adapter = buildAdapter()
+			let q = new URLSearchParams({
+				'hub.verify_token': VERIFY_TOKEN,
+				'hub.challenge': '12345',
+			})
+
+			expect(adapter.verifyChallenge!(q)).toBeNull()
+		})
+
+		test('returns null when challenge is missing', () => {
+			let adapter = buildAdapter()
+			let q = new URLSearchParams({
+				'hub.mode': 'subscribe',
+				'hub.verify_token': VERIFY_TOKEN,
+			})
+
+			expect(adapter.verifyChallenge!(q)).toBeNull()
+		})
+	})
+})

--- a/gateway/tests/adapters/whatsapp/adapter.test.ts
+++ b/gateway/tests/adapters/whatsapp/adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from 'bun:test'
 import { createHmac } from 'node:crypto'
-import { createWhatsappAdapter } from '../../../src/adapters/whatsapp'
+import { createWhatsappAdapter, type FetchLike } from '../../../src/adapters/whatsapp'
 import type { UserMappingService } from '../../../src/services/user-mapping'
 
 let PHONE_NUMBER_ID = '111222333'
@@ -18,7 +18,7 @@ function makeUserMapping(overrides: Partial<UserMappingService> = {}): UserMappi
 
 function buildAdapter(overrides: {
 	userMapping?: UserMappingService
-	fetch?: typeof fetch
+	fetch?: FetchLike
 } = {}) {
 	return createWhatsappAdapter({
 		phoneNumberId: PHONE_NUMBER_ID,
@@ -221,7 +221,7 @@ describe('createWhatsappAdapter', () => {
 	describe('sendReply', () => {
 		test('POSTs to the Meta Graph API with bearer auth and the right body', async () => {
 			let captured: { url: string; init: RequestInit } | null = null
-			let fakeFetch: typeof fetch = async (input, init) => {
+			let fakeFetch: FetchLike = async (input, init) => {
 				captured = { url: String(input), init: init ?? {} }
 				return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
 			}
@@ -237,7 +237,7 @@ describe('createWhatsappAdapter', () => {
 			expect(captured).not.toBeNull()
 			expect(captured!.url).toBe(`https://graph.facebook.com/v20.0/${PHONE_NUMBER_ID}/messages`)
 			expect(captured!.init.method).toBe('POST')
-			let headers = new Headers(captured!.init.headers as HeadersInit)
+			let headers = new Headers(captured!.init.headers as Record<string, string>)
 			expect(headers.get('authorization')).toBe(`Bearer ${ACCESS_TOKEN}`)
 			expect(headers.get('content-type')).toBe('application/json')
 			let body = JSON.parse(String(captured!.init.body))
@@ -250,7 +250,7 @@ describe('createWhatsappAdapter', () => {
 		})
 
 		test('throws on non-2xx response', async () => {
-			let fakeFetch: typeof fetch = async () =>
+			let fakeFetch: FetchLike = async () =>
 				new Response('{"error":{"message":"bad"}}', { status: 400 })
 			let adapter = buildAdapter({ fetch: fakeFetch })
 

--- a/gateway/tests/router/webhook.test.ts
+++ b/gateway/tests/router/webhook.test.ts
@@ -181,4 +181,72 @@ describe('webhook router', () => {
 
 		expect(res.status).toBe(500)
 	})
+
+	test('GET /webhook/:provider returns 200 + plain-text challenge when verifyChallenge succeeds', async () => {
+		let captured: URLSearchParams | null = null
+		let adapter = createMockAdapter({
+			verifyChallenge: (query) => {
+				captured = query
+				return 'CHALLENGE_TOKEN'
+			},
+		})
+		let adapters = new Map([['test', adapter]])
+		let service = new HandleInboundMessage({ processMessage: async () => 'ack' })
+		let app = buildApp(adapters, service)
+
+		let res = await app.fetch(
+			new Request(
+				'http://localhost/webhook/test?hub.mode=subscribe&hub.verify_token=t&hub.challenge=CHALLENGE_TOKEN',
+				{ method: 'GET' },
+			),
+		)
+
+		expect(res.status).toBe(200)
+		expect(await res.text()).toBe('CHALLENGE_TOKEN')
+		expect(captured).not.toBeNull()
+		expect(captured!.get('hub.challenge')).toBe('CHALLENGE_TOKEN')
+	})
+
+	test('GET /webhook/:provider returns 403 when verifyChallenge returns null', async () => {
+		let adapter = createMockAdapter({
+			verifyChallenge: () => null,
+		})
+		let adapters = new Map([['test', adapter]])
+		let service = new HandleInboundMessage({ processMessage: async () => 'ack' })
+		let app = buildApp(adapters, service)
+
+		let res = await app.fetch(
+			new Request(
+				'http://localhost/webhook/test?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=X',
+				{ method: 'GET' },
+			),
+		)
+
+		expect(res.status).toBe(403)
+	})
+
+	test('GET /webhook/:provider returns 404 when adapter has no verifyChallenge', async () => {
+		let adapter = createMockAdapter()
+		let adapters = new Map([['test', adapter]])
+		let service = new HandleInboundMessage({ processMessage: async () => 'ack' })
+		let app = buildApp(adapters, service)
+
+		let res = await app.fetch(
+			new Request('http://localhost/webhook/test?hub.mode=subscribe', { method: 'GET' }),
+		)
+
+		expect(res.status).toBe(404)
+	})
+
+	test('GET /webhook/:provider returns 404 for unknown provider', async () => {
+		let adapters = new Map<string, ChatAdapter>()
+		let service = new HandleInboundMessage({ processMessage: async () => 'ack' })
+		let app = buildApp(adapters, service)
+
+		let res = await app.fetch(
+			new Request('http://localhost/webhook/unknown?hub.mode=subscribe', { method: 'GET' }),
+		)
+
+		expect(res.status).toBe(404)
+	})
 })


### PR DESCRIPTION
Closes #101 (Step 6 of #94).

## Summary
- New `gateway/src/adapters/whatsapp/` adapter implementing `ChatAdapter` against Meta Cloud API directly via `fetch` (no SDK). `parseInbound` validates the Meta webhook envelope with Zod and rejects status-only payloads and non-text message types via parse errors so the router maps them to HTTP 400 through `InboundParseError`. `verifyWebhook` performs HMAC-SHA256 against the raw body and compares with `crypto.timingSafeEqual`. `sendReply` POSTs to `https://graph.facebook.com/v20.0/<phoneNumberId>/messages` with bearer auth and throws on non-2xx. `resolveUser` delegates to `UserMappingService.resolveOrCreate('whatsapp', senderId)` from step 7, which already deduplicates phone numbers across `whatsapp` and `sms` via `PHONE_PROVIDERS`.
- Adds an optional `verifyChallenge(query: URLSearchParams): string | null` to the `ChatAdapter` interface and a corresponding `GET /:provider` handler in the webhook router so Meta's one-time subscription handshake works end-to-end. Adapters that have no GET handshake (e.g. Telegram) leave it undefined and the router responds 404.
- Wires the adapter at boot in `gateway/src/index.ts`. Registration is gated on the four `WHATSAPP_*` env vars being present so local dev without Meta credentials still boots with an empty adapter map.

## Decisions
- **No 4096-char chunking.** Meta's per-text limit is 4096 chars, well above what the AI core emits; chunking would introduce ordering risks and isn't worth it. If/when the core grows long-form output we can add it behind the same `sendReply` boundary.
- **GET handshake via optional method, not a separate route.** Keeping it on the `ChatAdapter` interface puts provider knowledge in the adapter (verify-token comparison, query-param shape) rather than the router, and stays inert for adapters that don't opt in.
- **Optional env gating for boot.** Step 9 will replace this with a proper config module; making the env vars required at boot today would break local development for everyone who isn't running WhatsApp locally.
- **`FetchLike` instead of `typeof fetch`.** Bun's `typeof fetch` carries a `preconnect` member that production fetch impls and test fakes don't satisfy. A small WHATWG-compatible alias keeps the contract narrow.

## Test plan
- [x] `bun test` from `gateway/` (111 pass, 0 fail)
- [x] `bun run typecheck` from `gateway/`
- [x] Adapter unit tests cover: text-message parse, status-only rejection, non-text rejection, HMAC happy/tampered/missing/wrong-length/no-prefix, sendReply URL+headers+body, sendReply non-2xx error, resolveUser delegation, verifyChallenge happy/mismatch/missing-mode/missing-challenge.
- [x] Router tests cover GET handshake: 200+plain-text on success, 403 on null, 404 when adapter doesn't implement `verifyChallenge`, 404 for unknown provider.
- [ ] Manual end-to-end smoke against a real Meta sandbox (out of scope for this PR; will happen during step 8 deployment).

## Out of scope
- Telegram adapter (parallel PR for #100 / step 5).
- Config module (#103 / step 9).