### PR TITLE
chore(gateway): add per-service railway.json

### DIFF
--- a/gateway/railway.json
+++ b/gateway/railway.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://railway.app/railway.schema.json",
+	"build": {
+		"builder": "NIXPACKS",
+		"buildCommand": "bun install --production --frozen-lockfile"
+	},
+	"deploy": {
+		"startCommand": "cd gateway && NODE_ENV=production bun --silent run start",
+		"healthcheckPath": "/health",
+		"healthcheckTimeout": 30,
+		"restartPolicyType": "ON_FAILURE",
+		"restartPolicyMaxRetries": 10
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `gateway/railway.json` with deploy config that runs the gateway (`cd gateway && bun run start`) instead of falling through to the root `railway.json`'s backend start command.
- Mirrors the existing root config: NIXPACKS, frozen production install, `/health` probe, on-failure restart with the same retry budget.

## Why

Today the `matchmaker-gateway` Railway service inherits the repo-root `railway.json` and runs the **backend** process. That's why `POST /webhook/telegram` on the gateway domain returns 404 (backend has no such route) and `GET /` responds with the backend's `{"message":"Matchmaker API","version":"0.1.0"}`. A per-service config file lets the gateway service point at its own deploy config without changing what `matchmaker-server` does.

## Follow-up (manual, can't be automated from this PR)

- In Railway → **matchmaker-gateway** service → **Settings** → set **Config-as-Code Path** to `gateway/railway.json`.
- Confirm the gateway-only env vars are set on this service: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_JWT_SECRET`, `MCP_BASE_URL`, `ANTHROPIC_API_KEY`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_WEBHOOK_SECRET`. Do **not** set `PORT` (Railway injects `$PORT=8080`).
- Redeploy. Logs should show `Started server: http://localhost:8080` and `GET /` should return 404 (gateway has no root route), confirming gateway code is now running.

## Test plan

- [ ] After Step 1 Railway redeploys: `curl https://matchmaker-gateway-production.up.railway.app/health` → 200
- [ ] `curl https://matchmaker-gateway-production.up.railway.app/` → 404 plain text (no longer the backend's JSON)
- [ ] `curl https://api.telegram.org/bot<TOKEN>/getWebhookInfo` → `last_error_message` clears, `pending_update_count` drains
- [ ] DM the bot from Telegram → reply round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)